### PR TITLE
Updates to additional properties for Invoice

### DIFF
--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Machine.Specifications.Runner.Console" version="0.9.0" />
+</packages>

--- a/src/Stripe.Tests/App.config
+++ b/src/Stripe.Tests/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="StripeApiKey" value="test_api_key_here" />
+    <add key="StripeApiKey" value="cHScqnpIgSiFozbOsshJRxwaA4yv1SaG" />
   </appSettings>
 </configuration>

--- a/src/Stripe.Tests/App.config
+++ b/src/Stripe.Tests/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="StripeApiKey" value="cHScqnpIgSiFozbOsshJRxwaA4yv1SaG" />
+    <add key="StripeApiKey" value="test_api_key_here" />
   </appSettings>
 </configuration>

--- a/src/Stripe.Tests/Stripe.Tests.csproj
+++ b/src/Stripe.Tests/Stripe.Tests.csproj
@@ -107,7 +107,10 @@
     <Compile Include="infrastructure\when_passed_only_url_to_parameter_builder.cs" />
     <Compile Include="infrastructure\when_serializing_an_equals_datefilter.cs" />
     <Compile Include="infrastructure\when_serializing_a_datefilter_query.cs" />
+    <Compile Include="invoiceitems\when_updating_an_invoiceitem_metadata_only.cs" />
     <Compile Include="invoiceitems\when_creating_an_invoiceitem_with_an_api_key.cs" />
+    <Compile Include="invoices\test_data\stripe_invoice_update_options.cs" />
+    <Compile Include="invoices\when_updating_an_invoice.cs" />
     <Compile Include="invoices\when_closing_an_invoice.cs" />
     <Compile Include="invoices\when_creating_an_invoice_with_an_api_key.cs" />
     <Compile Include="invoices\when_creating_an_invoice_with_failed_charge.cs" />

--- a/src/Stripe.Tests/infrastructure/test_data/charge.json
+++ b/src/Stripe.Tests/infrastructure/test_data/charge.json
@@ -50,7 +50,7 @@
   "dispute": null,
   "metadata": {
   },
-  "statement_description": null,
+  "statement_descriptor": null,
   "fraud_details": {
     "stripe_report": "unavailable",
     "user_report": null

--- a/src/Stripe.Tests/infrastructure/test_data/invoice.json
+++ b/src/Stripe.Tests/infrastructure/test_data/invoice.json
@@ -32,7 +32,7 @@
           "trial_period_days": null,
           "metadata": {
           },
-          "statement_description": null
+          "statement_descriptor": null
         },
         "description": null,
         "metadata": {
@@ -65,7 +65,7 @@
   "subscription": "sub_4KrhgJ7EO0QG7x",
   "metadata": {
   },
-  "statement_description": null,
+  "statement_descriptor": null,
   "description": null,
   "receipt_number": null
 }

--- a/src/Stripe.Tests/infrastructure/test_data/invoice_item.json
+++ b/src/Stripe.Tests/infrastructure/test_data/invoice_item.json
@@ -26,6 +26,6 @@
     "trial_period_days": null,
     "metadata": {
     },
-    "statement_description": null
+    "statement_descriptor": null
   }
 }

--- a/src/Stripe.Tests/infrastructure/test_data/subscription.json
+++ b/src/Stripe.Tests/infrastructure/test_data/subscription.json
@@ -13,7 +13,7 @@
     "trial_period_days": null,
     "metadata": {
     },
-    "statement_description": null
+    "statement_descriptor": null
   },
   "object": "subscription",
   "start": 1417623744,

--- a/src/Stripe.Tests/infrastructure/test_data/transfer.json
+++ b/src/Stripe.Tests/infrastructure/test_data/transfer.json
@@ -15,6 +15,6 @@
   "failure_code": null,
   "metadata": {
   },
-  "statement_description": null,
+  "statement_descriptor": null,
   "recipient": "rc_imadethisup"
 }

--- a/src/Stripe.Tests/invoiceitems/test_data/stripe_invoiceitem_update_options.cs
+++ b/src/Stripe.Tests/invoiceitems/test_data/stripe_invoiceitem_update_options.cs
@@ -2,23 +2,39 @@
 
 namespace Stripe.Tests.test_data
 {
-    public static class stripe_invoiceitem_update_options
-    {
-        public static StripeInvoiceItemUpdateOptions Valid()
-        {
-            var stripeInvoiceItemUpdateOptions = new StripeInvoiceItemUpdateOptions()
-            {
-                Amount = 1001,
-                Description = "Test Invoice Item Update",
-                Metadata = new Dictionary<string, string>
+	public static class stripe_invoiceitem_update_options
+	{
+		public static StripeInvoiceItemUpdateOptions Valid()
+		{
+			var stripeInvoiceItemUpdateOptions = new StripeInvoiceItemUpdateOptions()
+			{
+				Amount = 1001,
+				Description = "Test Invoice Item Update",
+				Metadata = new Dictionary<string, string>
                 {
                     { "A", "Value-A" },
                     { "B", "Value-B" },
                     { "C", "Value-C" }
                 }
-            };
+			};
 
-            return stripeInvoiceItemUpdateOptions;
-        }
-    }
+			return stripeInvoiceItemUpdateOptions;
+		}
+
+		public static StripeInvoiceItemUpdateOptions MetadataOnly()
+		{
+			var stripeInvoiceItemUpdateOptions = new StripeInvoiceItemUpdateOptions()
+			{
+				Metadata = new Dictionary<string, string>
+                {
+                    { "A", "Value-A1" },
+                    { "B", "Value-B1" },
+                    { "C", "Value-C1" },
+                    { "D", "Value-D1" }
+                }
+			};
+
+			return stripeInvoiceItemUpdateOptions;
+		}
+	}
 }

--- a/src/Stripe.Tests/invoiceitems/test_data/stripe_invoiceitem_update_options.cs
+++ b/src/Stripe.Tests/invoiceitems/test_data/stripe_invoiceitem_update_options.cs
@@ -2,39 +2,39 @@
 
 namespace Stripe.Tests.test_data
 {
-	public static class stripe_invoiceitem_update_options
-	{
-		public static StripeInvoiceItemUpdateOptions Valid()
-		{
-			var stripeInvoiceItemUpdateOptions = new StripeInvoiceItemUpdateOptions()
-			{
-				Amount = 1001,
-				Description = "Test Invoice Item Update",
-				Metadata = new Dictionary<string, string>
+    public static class stripe_invoiceitem_update_options
+    {
+        public static StripeInvoiceItemUpdateOptions Valid()
+        {
+            var stripeInvoiceItemUpdateOptions = new StripeInvoiceItemUpdateOptions()
+            {
+                Amount = 1001,
+                Description = "Test Invoice Item Update",
+                Metadata = new Dictionary<string, string>
                 {
                     { "A", "Value-A" },
                     { "B", "Value-B" },
                     { "C", "Value-C" }
                 }
-			};
+            };
 
-			return stripeInvoiceItemUpdateOptions;
-		}
+            return stripeInvoiceItemUpdateOptions;
+        }
 
-		public static StripeInvoiceItemUpdateOptions MetadataOnly()
-		{
-			var stripeInvoiceItemUpdateOptions = new StripeInvoiceItemUpdateOptions()
-			{
-				Metadata = new Dictionary<string, string>
+        public static StripeInvoiceItemUpdateOptions MetadataOnly()
+        {
+            var stripeInvoiceItemUpdateOptions = new StripeInvoiceItemUpdateOptions()
+            {
+                Metadata = new Dictionary<string, string>
                 {
                     { "A", "Value-A1" },
                     { "B", "Value-B1" },
                     { "C", "Value-C1" },
                     { "D", "Value-D1" }
                 }
-			};
+            };
 
-			return stripeInvoiceItemUpdateOptions;
-		}
-	}
+            return stripeInvoiceItemUpdateOptions;
+        }
+    }
 }

--- a/src/Stripe.Tests/invoiceitems/when_updating_an_invoiceitem_metadata_only.cs
+++ b/src/Stripe.Tests/invoiceitems/when_updating_an_invoiceitem_metadata_only.cs
@@ -1,0 +1,42 @@
+﻿using Machine.Specifications;
+
+namespace Stripe.Tests
+{
+	public class when_updating_an_invoiceitem_metadata_only
+	{
+		private static StripeInvoiceItemUpdateOptions StripeInvoiceItemUpdateOptions;
+		private static StripeInvoiceItemCreateOptions StripeInvoiceItemCreateOptions;
+		private static StripeInvoiceItem _stripeInvoiceItem;
+		private static string _stripeInvoiceItemId;
+		private static StripeInvoiceItemService _stripeInvoiceItemService;
+
+		Establish context = () =>
+		{
+			var stripeCustomerService = new StripeCustomerService();
+			var stripeCustomer = stripeCustomerService.Create(test_data.stripe_customer_create_options.ValidCard());
+
+			_stripeInvoiceItemService = new StripeInvoiceItemService();
+			StripeInvoiceItemCreateOptions = test_data.stripe_invoiceitem_create_options.Valid(stripeCustomer.Id);
+
+			var createdInvoice = _stripeInvoiceItemService.Create(StripeInvoiceItemCreateOptions);
+			_stripeInvoiceItemId = createdInvoice.Id;
+
+			StripeInvoiceItemUpdateOptions = test_data.stripe_invoiceitem_update_options.MetadataOnly();
+		};
+
+		Because of = () =>
+			_stripeInvoiceItem = _stripeInvoiceItemService.Update(_stripeInvoiceItemId, StripeInvoiceItemUpdateOptions);
+
+		It should_have_the_correct_amount = () =>
+			_stripeInvoiceItem.Amount.ShouldEqual(StripeInvoiceItemCreateOptions.Amount);
+
+		It should_have_the_correct_description = () =>
+			_stripeInvoiceItem.Description.ShouldEqual(StripeInvoiceItemCreateOptions.Description);
+
+		It should_have_metadata = () =>
+			_stripeInvoiceItem.Metadata.Count.ShouldEqual(4);
+
+		It should_have_the_correct_metadata = () =>
+			_stripeInvoiceItem.Metadata.ShouldContainOnly(StripeInvoiceItemUpdateOptions.Metadata);
+	}
+}

--- a/src/Stripe.Tests/invoices/test_data/stripe_invoice_update_options.cs
+++ b/src/Stripe.Tests/invoices/test_data/stripe_invoice_update_options.cs
@@ -9,7 +9,7 @@ namespace Stripe.Tests.test_data
             var stripeInvoiceUpdateOptions = new StripeInvoiceUpdateOptions()
             {
                 Description = "Invoice Description",
-                StatementDescription = "ST_DESC", // must be less than 15 char
+				StatementDescriptor = "ST_DESC", // must be less than 15 char
                 Metadata = new Dictionary<string, string>
                 {
                     { "A", "Value-A" },
@@ -35,7 +35,7 @@ namespace Stripe.Tests.test_data
         {
             var stripeInvoiceUpdateOptions = new StripeInvoiceUpdateOptions()
             {
-                StatementDescription = "ST_DESC NEW" // must be less than 15 char
+				StatementDescriptor = "ST_DESC NEW" // must be less than 15 char
             };
 
             return stripeInvoiceUpdateOptions;

--- a/src/Stripe.Tests/invoices/test_data/stripe_invoice_update_options.cs
+++ b/src/Stripe.Tests/invoices/test_data/stripe_invoice_update_options.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+
+namespace Stripe.Tests.test_data
+{
+    public static class stripe_invoice_update_options
+    {
+        public static StripeInvoiceUpdateOptions Valid()
+        {
+            var stripeInvoiceUpdateOptions = new StripeInvoiceUpdateOptions()
+            {
+                Description = "Invoice Description",
+                StatementDescription = "ST_DESC", // must be less than 15 char
+                Metadata = new Dictionary<string, string>
+                {
+                    { "A", "Value-A" },
+                    { "B", "Value-B" },
+                    { "C", "Value-C" }
+                }
+            };
+
+            return stripeInvoiceUpdateOptions;
+        }
+
+        public static StripeInvoiceUpdateOptions ForgivenOnly()
+        {
+            var stripeInvoiceUpdateOptions = new StripeInvoiceUpdateOptions()
+            {
+                Forgiven = true
+            };
+
+            return stripeInvoiceUpdateOptions;
+        }
+
+        public static StripeInvoiceUpdateOptions StatementDescriptionOnly()
+        {
+            var stripeInvoiceUpdateOptions = new StripeInvoiceUpdateOptions()
+            {
+                StatementDescription = "ST_DESC NEW" // must be less than 15 char
+            };
+
+            return stripeInvoiceUpdateOptions;
+        }
+
+        public static StripeInvoiceUpdateOptions MetadataOnly()
+        {
+            var stripeInvoiceUpdateOptions = new StripeInvoiceUpdateOptions()
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "A", "Value-A1" },
+                    { "B", "Value-B1" },
+                    { "C", "Value-C1" },
+                    { "D", "Value-D1" }
+                }
+            };
+
+            return stripeInvoiceUpdateOptions;
+        }
+    }
+}

--- a/src/Stripe.Tests/invoices/when_updating_an_invoice.cs
+++ b/src/Stripe.Tests/invoices/when_updating_an_invoice.cs
@@ -40,8 +40,8 @@ namespace Stripe.Tests
 		It should_have_the_correct_description = () =>
 			_stripeInvoice.Description.ShouldEqual(StripeInvoiceUpdateOptions.Description);
 
-		It should_have_the_correct_statement_description = () =>
-			_stripeInvoice.StatementDescription.ShouldEqual(StripeInvoiceUpdateOptions.StatementDescription);
+		It should_have_the_correct_statement_descriptor = () =>
+			_stripeInvoice.StatementDescriptor.ShouldEqual(StripeInvoiceUpdateOptions.StatementDescriptor);
 
 		It should_have_the_correct_value_for_forgiven = () =>
 			_stripeInvoice.Forgiven.ShouldEqual(false);

--- a/src/Stripe.Tests/invoices/when_updating_an_invoice.cs
+++ b/src/Stripe.Tests/invoices/when_updating_an_invoice.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using Machine.Specifications;
+
+namespace Stripe.Tests
+{
+	public class when_updating_an_invoice
+	{
+		private static StripeInvoiceUpdateOptions StripeInvoiceUpdateOptions;
+		private static StripeInvoice _stripeInvoice;
+		private static List<StripeInvoice> _stripeInvoiceList;
+		private static StripeInvoiceService _stripeInvoiceService;
+
+		Establish context = () =>
+		{
+			var stripePlanService = new StripePlanService();
+			var stripePlan = stripePlanService.Create(test_data.stripe_plan_create_options.Valid());
+
+			var stripeCouponService = new StripeCouponService();
+			var stripeCoupon = stripeCouponService.Create(test_data.stripe_coupon_create_options.Valid());
+
+			var stripeCustomerService = new StripeCustomerService();
+			var stripeCustomerCreateOptions = test_data.stripe_customer_create_options.ValidCard(stripePlan.Id, stripeCoupon.Id);
+			var stripeCustomer = stripeCustomerService.Create(stripeCustomerCreateOptions);
+
+			_stripeInvoiceService = new StripeInvoiceService(ConfigurationManager.AppSettings["StripeApiKey"]);
+			_stripeInvoiceList = _stripeInvoiceService.List(new StripeInvoiceListOptions { CustomerId = stripeCustomer.Id }).ToList();
+
+			StripeInvoiceUpdateOptions = test_data.stripe_invoice_update_options.Valid();
+		};
+
+		Because of = () =>
+			_stripeInvoice = _stripeInvoiceService.Update(_stripeInvoiceList.First().Id, StripeInvoiceUpdateOptions);
+		
+		It should_have_the_correct_value_for_closed = () =>
+			_stripeInvoice.Closed.ShouldEqual(_stripeInvoiceList.First().Closed);
+
+		It should_have_the_correct_description = () =>
+			_stripeInvoice.Description.ShouldEqual(StripeInvoiceUpdateOptions.Description);
+
+		It should_have_the_correct_statement_description = () =>
+			_stripeInvoice.StatementDescription.ShouldEqual(StripeInvoiceUpdateOptions.StatementDescription);
+
+		It should_have_the_correct_value_for_forgiven = () =>
+			_stripeInvoice.Forgiven.ShouldEqual(false);
+
+		It should_have_metadata = () =>
+			_stripeInvoice.Metadata.Count.ShouldEqual(3);
+
+		It should_have_the_correct_metadata = () =>
+			_stripeInvoice.Metadata.ShouldContainOnly(StripeInvoiceUpdateOptions.Metadata);
+	}
+}

--- a/src/Stripe.Tests/plans/plan_behaviors.cs
+++ b/src/Stripe.Tests/plans/plan_behaviors.cs
@@ -32,8 +32,8 @@ namespace Stripe.Tests
         It should_have_a_created_date = () =>
             StripePlan.Created.ShouldNotBeNull();
 
-        It should_have_the_correct_statement_description = () =>
-            StripePlan.StatementDescription.ShouldEqual(StripePlanCreateOptions.StatementDescription);
+		It should_have_the_correct_statement_descriptor = () =>
+			StripePlan.StatementDescriptor.ShouldEqual(StripePlanCreateOptions.StatementDescriptor);
 
         It should_have_the_correct_live_mode = () =>
             StripePlan.LiveMode.ShouldEqual(false);

--- a/src/Stripe.Tests/plans/plan_behaviors.cs
+++ b/src/Stripe.Tests/plans/plan_behaviors.cs
@@ -32,8 +32,8 @@ namespace Stripe.Tests
         It should_have_a_created_date = () =>
             StripePlan.Created.ShouldNotBeNull();
 
-		It should_have_the_correct_statement_descriptor = () =>
-			StripePlan.StatementDescriptor.ShouldEqual(StripePlanCreateOptions.StatementDescriptor);
+        It should_have_the_correct_statement_descriptor = () =>
+            StripePlan.StatementDescriptor.ShouldEqual(StripePlanCreateOptions.StatementDescriptor);
 
         It should_have_the_correct_live_mode = () =>
             StripePlan.LiveMode.ShouldEqual(false);

--- a/src/Stripe.Tests/plans/test_data/stripe_plan_create_options.cs
+++ b/src/Stripe.Tests/plans/test_data/stripe_plan_create_options.cs
@@ -20,7 +20,7 @@ namespace Stripe.Tests.test_data
                     { "A", "Value-A" },
                     { "B", "Value-B" }
                 },
-				StatementDescriptor = "heyyyy ya!"
+                StatementDescriptor = "heyyyy ya!"
             };
         }
     }

--- a/src/Stripe.Tests/plans/test_data/stripe_plan_create_options.cs
+++ b/src/Stripe.Tests/plans/test_data/stripe_plan_create_options.cs
@@ -20,7 +20,7 @@ namespace Stripe.Tests.test_data
                     { "A", "Value-A" },
                     { "B", "Value-B" }
                 },
-                StatementDescription = "heyyyy ya!"
+				StatementDescriptor = "heyyyy ya!"
             };
         }
     }

--- a/src/Stripe.Tests/plans/test_data/stripe_plan_update_options.cs
+++ b/src/Stripe.Tests/plans/test_data/stripe_plan_update_options.cs
@@ -15,7 +15,7 @@ namespace Stripe.Tests.test_data
                     { "B", "Value-B" },
                     { "C", "Value-C" }
                 },
-				StatementDescriptor = "heyyyy ya?"
+                StatementDescriptor = "heyyyy ya?"
             };
         }
     }

--- a/src/Stripe.Tests/plans/test_data/stripe_plan_update_options.cs
+++ b/src/Stripe.Tests/plans/test_data/stripe_plan_update_options.cs
@@ -15,7 +15,7 @@ namespace Stripe.Tests.test_data
                     { "B", "Value-B" },
                     { "C", "Value-C" }
                 },
-                StatementDescription = "heyyyy ya?"
+				StatementDescriptor = "heyyyy ya?"
             };
         }
     }

--- a/src/Stripe.Tests/plans/when_updating_a_plan.cs
+++ b/src/Stripe.Tests/plans/when_updating_a_plan.cs
@@ -34,7 +34,7 @@ namespace Stripe.Tests
         It should_have_correct_metadata = () =>
             StripePlan.Metadata.ShouldContainOnly(StripePlanUpdateOptions.Metadata);
 
-		It should_have_the_new_statement_descriptor = () =>
-			StripePlan.StatementDescriptor.ShouldEqual(StripePlanUpdateOptions.StatementDescriptor);
+        It should_have_the_new_statement_descriptor = () =>
+            StripePlan.StatementDescriptor.ShouldEqual(StripePlanUpdateOptions.StatementDescriptor);
     }
 }

--- a/src/Stripe.Tests/plans/when_updating_a_plan.cs
+++ b/src/Stripe.Tests/plans/when_updating_a_plan.cs
@@ -34,7 +34,7 @@ namespace Stripe.Tests
         It should_have_correct_metadata = () =>
             StripePlan.Metadata.ShouldContainOnly(StripePlanUpdateOptions.Metadata);
 
-        It should_have_the_new_statement_description = () =>
-            StripePlan.StatementDescription.ShouldEqual(StripePlanUpdateOptions.StatementDescription);
+		It should_have_the_new_statement_descriptor = () =>
+			StripePlan.StatementDescriptor.ShouldEqual(StripePlanUpdateOptions.StatementDescriptor);
     }
 }

--- a/src/Stripe.Tests/transfers/test_data/stripe_transfer_create_options.cs
+++ b/src/Stripe.Tests/transfers/test_data/stripe_transfer_create_options.cs
@@ -13,7 +13,7 @@ namespace Stripe.Tests.test_data
                 Currency = "usd",
                 Recipient = "self",
                 Description = "test-transfer-description-" + Guid.NewGuid(),
-				StatementDescriptor = "test-transfer-statement-descriptor" + Guid.NewGuid(),
+                StatementDescriptor = "test-transfer-statement-descriptor" + Guid.NewGuid(),
                 Metadata = new Dictionary<string, string>
                 {
                     { "A", "Value-A" },

--- a/src/Stripe.Tests/transfers/test_data/stripe_transfer_create_options.cs
+++ b/src/Stripe.Tests/transfers/test_data/stripe_transfer_create_options.cs
@@ -13,7 +13,7 @@ namespace Stripe.Tests.test_data
                 Currency = "usd",
                 Recipient = "self",
                 Description = "test-transfer-description-" + Guid.NewGuid(),
-                StatementDescription = "test-transfer-statement-descriptor" + Guid.NewGuid(),
+				StatementDescriptor = "test-transfer-statement-descriptor" + Guid.NewGuid(),
                 Metadata = new Dictionary<string, string>
                 {
                     { "A", "Value-A" },

--- a/src/Stripe.Tests/transfers/transfer_behaviors.cs
+++ b/src/Stripe.Tests/transfers/transfer_behaviors.cs
@@ -36,7 +36,7 @@ namespace Stripe.Tests
         It should_have_the_correct_description = () =>
             StripeTransfer.Description.ShouldEqual(StripeTransferCreateOptions.Description);
 
-        It should_have_the_correct_statement_description = () =>
-            StripeTransfer.StatementDescription.ShouldEqual(StripeTransferCreateOptions.StatementDescription);
+		It should_have_the_correct_statement_descriptor = () =>
+			StripeTransfer.StatementDescriptor.ShouldEqual(StripeTransferCreateOptions.StatementDescriptor);
     }
 }

--- a/src/Stripe.Tests/transfers/transfer_behaviors.cs
+++ b/src/Stripe.Tests/transfers/transfer_behaviors.cs
@@ -36,7 +36,7 @@ namespace Stripe.Tests
         It should_have_the_correct_description = () =>
             StripeTransfer.Description.ShouldEqual(StripeTransferCreateOptions.Description);
 
-		It should_have_the_correct_statement_descriptor = () =>
-			StripeTransfer.StatementDescriptor.ShouldEqual(StripeTransferCreateOptions.StatementDescriptor);
+        It should_have_the_correct_statement_descriptor = () =>
+            StripeTransfer.StatementDescriptor.ShouldEqual(StripeTransferCreateOptions.StatementDescriptor);
     }
 }

--- a/src/Stripe/Entities/StripeCharge.cs
+++ b/src/Stripe/Entities/StripeCharge.cs
@@ -91,7 +91,7 @@ namespace Stripe
         [JsonProperty("receipt_email")]
         public string ReceiptEmail { get; set; }
 
-        [JsonProperty("statement_description")]
-        public string StatementDescription { get; set; }
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
     }
 }

--- a/src/Stripe/Entities/StripeInvoice.cs
+++ b/src/Stripe/Entities/StripeInvoice.cs
@@ -106,8 +106,8 @@ namespace Stripe
         [JsonProperty("receipt_number")]
         public string ReceiptNumber { get; set; }
 
-        [JsonProperty("statement_description")]
-        public string StatementDescription { get; set; }
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
 
         [JsonProperty("subscription")]
         public string SubscriptionId { get; set; }

--- a/src/Stripe/Entities/StripePlan.cs
+++ b/src/Stripe/Entities/StripePlan.cs
@@ -29,8 +29,8 @@ namespace Stripe
         [JsonProperty("livemode")]
         public bool? LiveMode { get; set; }
 
-        [JsonProperty("statement_description")]
-        public string StatementDescription { get; set; }
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
 
         [JsonProperty("trial_period_days")]
         public int? TrialPeriodDays { get; set; }

--- a/src/Stripe/Entities/StripeTransfer.cs
+++ b/src/Stripe/Entities/StripeTransfer.cs
@@ -78,7 +78,7 @@ namespace Stripe
             }
         }
 
-        [JsonProperty("statement_description")]
-        public string StatementDescription { get; set; }
+		[JsonProperty("statement_descriptor")]
+		public string StatementDescriptor { get; set; }
     }
 }

--- a/src/Stripe/Entities/StripeTransfer.cs
+++ b/src/Stripe/Entities/StripeTransfer.cs
@@ -78,7 +78,7 @@ namespace Stripe
             }
         }
 
-		[JsonProperty("statement_descriptor")]
-		public string StatementDescriptor { get; set; }
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
     }
 }

--- a/src/Stripe/Services/Charges/StripeChargeCreateOptions.cs
+++ b/src/Stripe/Services/Charges/StripeChargeCreateOptions.cs
@@ -26,8 +26,8 @@ namespace Stripe
         [JsonProperty("capture")]
         public bool? Capture { get; set; }
 
-        [JsonProperty("statement_description")]
-        public string StatementDescription { get; set; }
+		[JsonProperty("statement_descriptor")]
+		public string StatementDescriptor { get; set; }
 
         [JsonProperty("receipt_email")]
         public string ReceiptEmail { get; set; }

--- a/src/Stripe/Services/Charges/StripeChargeCreateOptions.cs
+++ b/src/Stripe/Services/Charges/StripeChargeCreateOptions.cs
@@ -26,8 +26,8 @@ namespace Stripe
         [JsonProperty("capture")]
         public bool? Capture { get; set; }
 
-		[JsonProperty("statement_descriptor")]
-		public string StatementDescriptor { get; set; }
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
 
         [JsonProperty("receipt_email")]
         public string ReceiptEmail { get; set; }

--- a/src/Stripe/Services/InvoiceItems/StripeInvoiceItemUpdateOptions.cs
+++ b/src/Stripe/Services/InvoiceItems/StripeInvoiceItemUpdateOptions.cs
@@ -6,7 +6,7 @@ namespace Stripe
     public class StripeInvoiceItemUpdateOptions
     {
         [JsonProperty("amount")]
-        public int Amount { get; set; }
+        public int? Amount { get; set; }
 
         [JsonProperty("currency")]
         public string Currency { get; set; }

--- a/src/Stripe/Services/Invoices/StripeInvoiceUpdateOptions.cs
+++ b/src/Stripe/Services/Invoices/StripeInvoiceUpdateOptions.cs
@@ -3,24 +3,24 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-	public class StripeInvoiceUpdateOptions
-	{
-		[JsonProperty("closed")]
-		public bool? Closed { get; set; }
+    public class StripeInvoiceUpdateOptions
+    {
+        [JsonProperty("closed")]
+        public bool? Closed { get; set; }
 
-		[JsonProperty("application_fee")]
-		public int? ApplicationFee { get; set; }
+        [JsonProperty("application_fee")]
+        public int? ApplicationFee { get; set; }
 
-		[JsonProperty("description")]
-		public string Description { get; set; }
+        [JsonProperty("description")]
+        public string Description { get; set; }
 
-		[JsonProperty("forgiven")]
-		public bool? Forgiven { get; set; }
+        [JsonProperty("forgiven")]
+        public bool? Forgiven { get; set; }
 
-		[JsonProperty("statement_descriptor")]
-		public string StatementDescriptor { get; set; }
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
 
-		[JsonProperty("metadata")]
-		public Dictionary<string, string> Metadata { get; set; }
-	}
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+    }
 }

--- a/src/Stripe/Services/Invoices/StripeInvoiceUpdateOptions.cs
+++ b/src/Stripe/Services/Invoices/StripeInvoiceUpdateOptions.cs
@@ -1,10 +1,26 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeInvoiceUpdateOptions
-    {
-        [JsonProperty("closed")]
-        public bool Closed { get; set; }
-    }
+	public class StripeInvoiceUpdateOptions
+	{
+		[JsonProperty("closed")]
+		public bool? Closed { get; set; }
+
+		[JsonProperty("application_fee")]
+		public int? ApplicationFee { get; set; }
+
+		[JsonProperty("description")]
+		public string Description { get; set; }
+
+		[JsonProperty("forgiven")]
+		public bool? Forgiven { get; set; }
+
+		[JsonProperty("statement_description")]
+		public string StatementDescription { get; set; }
+
+		[JsonProperty("metadata")]
+		public Dictionary<string, string> Metadata { get; set; }
+	}
 }

--- a/src/Stripe/Services/Invoices/StripeInvoiceUpdateOptions.cs
+++ b/src/Stripe/Services/Invoices/StripeInvoiceUpdateOptions.cs
@@ -17,8 +17,8 @@ namespace Stripe
 		[JsonProperty("forgiven")]
 		public bool? Forgiven { get; set; }
 
-		[JsonProperty("statement_description")]
-		public string StatementDescription { get; set; }
+		[JsonProperty("statement_descriptor")]
+		public string StatementDescriptor { get; set; }
 
 		[JsonProperty("metadata")]
 		public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe/Services/Plans/StripePlanCreateOptions.cs
+++ b/src/Stripe/Services/Plans/StripePlanCreateOptions.cs
@@ -26,8 +26,8 @@ namespace Stripe
         [JsonProperty("trial_period_days")]
         public int? TrialPeriodDays { get; set; }
 
-        [JsonProperty("statement_description")]
-        public string StatementDescription { get; set; }
+		[JsonProperty("statement_descriptor")]
+		public string StatementDescriptor { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe/Services/Plans/StripePlanCreateOptions.cs
+++ b/src/Stripe/Services/Plans/StripePlanCreateOptions.cs
@@ -26,8 +26,8 @@ namespace Stripe
         [JsonProperty("trial_period_days")]
         public int? TrialPeriodDays { get; set; }
 
-		[JsonProperty("statement_descriptor")]
-		public string StatementDescriptor { get; set; }
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe/Services/Plans/StripePlanUpdateOptions.cs
+++ b/src/Stripe/Services/Plans/StripePlanUpdateOptions.cs
@@ -11,7 +11,7 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
-        [JsonProperty("statement_description")]
-        public string StatementDescription { get; set; }
+		[JsonProperty("statement_descriptor")]
+		public string StatementDescriptor { get; set; }
     }
 }

--- a/src/Stripe/Services/Plans/StripePlanUpdateOptions.cs
+++ b/src/Stripe/Services/Plans/StripePlanUpdateOptions.cs
@@ -11,7 +11,7 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
-		[JsonProperty("statement_descriptor")]
-		public string StatementDescriptor { get; set; }
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
     }
 }

--- a/src/Stripe/Services/Transfers/StripeTransferCreateOptions.cs
+++ b/src/Stripe/Services/Transfers/StripeTransferCreateOptions.cs
@@ -17,8 +17,8 @@ namespace Stripe
         [JsonProperty("description")]
         public string Description { get; set; }
 
-        [JsonProperty("statement_description")]
-        public string StatementDescription { get; set; }
+		[JsonProperty("statement_descriptor")]
+		public string StatementDescriptor { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe/Services/Transfers/StripeTransferCreateOptions.cs
+++ b/src/Stripe/Services/Transfers/StripeTransferCreateOptions.cs
@@ -17,8 +17,8 @@ namespace Stripe
         [JsonProperty("description")]
         public string Description { get; set; }
 
-		[JsonProperty("statement_descriptor")]
-		public string StatementDescriptor { get; set; }
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }


### PR DESCRIPTION
This adds the additional options as specified in https://stripe.com/docs/api#update_invoice

Also, I made a quick change to set Amount to a nullable int on InvoiceItemUpdateOptions because if you just updated the metadata on the invoiceitem, it was resetting the Amount to `0` since it wasn't nullable.