### PR TITLE
Fixed bug in StripeCustomerService Get with missing url re-assignment

### DIFF
--- a/src/Stripe/Services/Customers/StripeCustomerService.cs
+++ b/src/Stripe/Services/Customers/StripeCustomerService.cs
@@ -20,7 +20,7 @@ namespace Stripe
         public virtual StripeCustomer Get(string customerId)
         {
             var url = string.Format("{0}/{1}", Urls.Customers, customerId);
-            this.ApplyAllParameters(null, url, false);
+            url = this.ApplyAllParameters(null, url, false);
 
             var response = Requestor.GetString(url, ApiKey);
 


### PR DESCRIPTION
Simple fix. I noticed this when I wasn't getting the expanded `StripeDefaultCard` back with my customer `Get`.