### PR TITLE
fix to accommodate expandable properties on invoice

### DIFF
--- a/src/Stripe/Services/Invoices/StripeInvoiceService.cs
+++ b/src/Stripe/Services/Invoices/StripeInvoiceService.cs
@@ -13,6 +13,7 @@ namespace Stripe
         public virtual StripeInvoice Get(string invoiceId)
         {
             var url = string.Format("{0}/{1}", Urls.Invoices, invoiceId);
+            url = this.ApplyAllParameters(null, url, false);
 
             var response = Requestor.GetString(url, ApiKey);
 


### PR DESCRIPTION
Looks like this method was left out when accommodating expandables.  Its just a one line change @ line 16. Don't know why it thinks the other lines needed to deleted and re-added.