### PR TITLE
Adding ability to set Bank Account token from Stripe.js

### DIFF
--- a/src/Stripe.Tests/infrastructure/test_data/sample_object.cs
+++ b/src/Stripe.Tests/infrastructure/test_data/sample_object.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
+using Stripe.Infrastructure;
 
 namespace Stripe.Tests.test_data
 {
@@ -28,6 +30,14 @@ namespace Stripe.Tests.test_data
             SubObject = new sample_sub_object()
             {
                 Pi = "3.1415"
+            };
+            SubObjectWithConverter = new sample_sub_object_with_custom_converter()
+            {
+                Value = "Hello"
+            };
+            NullSubObjectWithConverter = new sample_sub_object_with_custom_converter()
+            {
+                Value = null
             };
         }
 
@@ -65,11 +75,35 @@ namespace Stripe.Tests.test_data
 
         [JsonProperty("subobject")]
         public sample_sub_object SubObject { get; set; }
+
+        [JsonProperty("subobjectwithconverter")]
+        public sample_sub_object_with_custom_converter SubObjectWithConverter { get; set; }
+
+        [JsonProperty("nullsubobjectwithconverter")]
+        public sample_sub_object_with_custom_converter NullSubObjectWithConverter { get; set; }
     }
 
     public class sample_sub_object
     {
         [JsonProperty("pi")]
         public string Pi { get; set; }
+    }
+
+
+    [QueryStringParameterConverter(typeof(sample_type_converter))]
+    public class sample_sub_object_with_custom_converter
+    {
+        public string Value { get; set; }
+    }
+
+    internal class sample_type_converter 
+        : QueryStringParameterConverter<sample_sub_object_with_custom_converter>
+    {
+        public override string ConvertToQueryStringValue(sample_sub_object_with_custom_converter @object)
+        {
+            if (@object.Value == null) return null;
+
+            return new string(@object.Value.Reverse().ToArray());
+        }
     }
 }

--- a/src/Stripe.Tests/infrastructure/test_data/sample_object.cs
+++ b/src/Stripe.Tests/infrastructure/test_data/sample_object.cs
@@ -74,13 +74,13 @@ namespace Stripe.Tests.test_data
         public StripeDateFilter ComplexDateFilter { get; set; }
 
         [JsonProperty("subobject")]
-        public sample_sub_object SubObject { get; set; }
+        public object SubObject { get; set; }
 
         [JsonProperty("subobjectwithconverter")]
-        public sample_sub_object_with_custom_converter SubObjectWithConverter { get; set; }
+        public object SubObjectWithConverter { get; set; }
 
         [JsonProperty("nullsubobjectwithconverter")]
-        public sample_sub_object_with_custom_converter NullSubObjectWithConverter { get; set; }
+        public object NullSubObjectWithConverter { get; set; }
     }
 
     public class sample_sub_object

--- a/src/Stripe.Tests/infrastructure/test_data/sample_object.cs
+++ b/src/Stripe.Tests/infrastructure/test_data/sample_object.cs
@@ -12,6 +12,7 @@ namespace Stripe.Tests.test_data
         {
             StringContainingText = "Foo";
             StringWithDifferentName = "Foo";
+            StringWithEncoding = "H=I";
             Number = 42;
             Metadata = new Dictionary<string, string> {
                 { "A", "Value-A" },
@@ -23,6 +24,10 @@ namespace Stripe.Tests.test_data
             {
                 LessThan = DateTime.Parse("2100-01-01"),
                 GreaterThan = DateTime.Parse("2000-01-01")
+            };
+            SubObject = new sample_sub_object()
+            {
+                Pi = "3.1415"
             };
         }
 
@@ -36,6 +41,9 @@ namespace Stripe.Tests.test_data
 
         [JsonProperty("stringcontainingnull")]
         public string StringContainingNull { get; set; }
+
+        [JsonProperty("stringwithencoding")]
+        public string StringWithEncoding { get; set; }
 
         [JsonProperty("number")]
         public int Number { get; set; }
@@ -54,5 +62,14 @@ namespace Stripe.Tests.test_data
 
         [JsonProperty("datecomplex")]
         public StripeDateFilter ComplexDateFilter { get; set; }
+
+        [JsonProperty("subobject")]
+        public sample_sub_object SubObject { get; set; }
+    }
+
+    public class sample_sub_object
+    {
+        [JsonProperty("pi")]
+        public string Pi { get; set; }
     }
 }

--- a/src/Stripe.Tests/infrastructure/when_building_parameters.cs
+++ b/src/Stripe.Tests/infrastructure/when_building_parameters.cs
@@ -45,5 +45,11 @@ namespace Stripe.Tests
 
         It should_contain_metadata_as_inline_items = () =>
             _result.ShouldContain("metadata[A]=Value-A");
+
+        It should_encode_string_properties = () =>
+            _result.ShouldContain("stringwithencoding=H%3dI");
+
+        It should_contain_properties_with_complex_objects = () =>
+            _result.ShouldContain("subobject[pi]=3.1415");
     }
 }

--- a/src/Stripe.Tests/infrastructure/when_building_parameters.cs
+++ b/src/Stripe.Tests/infrastructure/when_building_parameters.cs
@@ -51,5 +51,11 @@ namespace Stripe.Tests
 
         It should_contain_properties_with_complex_objects = () =>
             _result.ShouldContain("subobject[pi]=3.1415");
+
+        It should_contain_properties_with_custom_converters = () =>
+            _result.ShouldContain("subobjectwithconverter=olleH");
+
+        It should_not_contain_properties_with_null_converted_values = () =>
+            _result.ShouldNotContain("nullsubobjectwithconverter=");
     }
 }

--- a/src/Stripe.Tests/recipients/test_data/stripe_recipient_create_options.cs
+++ b/src/Stripe.Tests/recipients/test_data/stripe_recipient_create_options.cs
@@ -11,9 +11,12 @@ namespace Stripe.Tests.test_data
                 Name = "Johnny Tenderloin",
                 Type = "individual",
                 TaxId = "000000000",
-                BankAccountNumber = "000123456789",
-                BankAccountRoutingNumber = "110000000",
-                BankAccountCountry = "US",
+                BankAccount = new BankAccountOptions
+                {
+                    AccountNumber = "000123456789",
+                    RoutingNumber = "110000000",
+                    Country = "US",
+                },
                 Email = "pork@email.com",
                 Description = "Johnny Tenderloin (pork@email.com)",
                 Metadata = new Dictionary<string, string>

--- a/src/Stripe/Infrastructure/IQueryStringParameterConverter.cs
+++ b/src/Stripe/Infrastructure/IQueryStringParameterConverter.cs
@@ -1,0 +1,7 @@
+﻿namespace Stripe.Infrastructure
+{
+    internal interface IQueryStringParameterConverter
+    {
+        string ConvertToQueryStringValue(object @object);
+    }
+}

--- a/src/Stripe/Infrastructure/ParameterBuilder.cs
+++ b/src/Stripe/Infrastructure/ParameterBuilder.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Web;
 using Newtonsoft.Json;
 using Stripe.Infrastructure;
@@ -16,51 +17,11 @@ namespace Stripe
     {
         public static string ApplyAllParameters(this StripeService service, object obj, string url, bool isListMethod)
         {
-            string newUrl = url;
+            var queryStringProperties = new Dictionary<string, List<string>>();
 
             if (obj != null)
             {
-                foreach (var property in obj.GetType().GetProperties(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance))
-                {
-                    var value = property.GetValue(obj, null);
-                    if (value == null) continue;
-
-                    foreach (var attribute in property.GetCustomAttributes(typeof(JsonPropertyAttribute), false).Cast<JsonPropertyAttribute>())
-                    {
-                        if (string.Compare(attribute.PropertyName, "metadata", true) == 0)
-                        {
-                            var metadata = (Dictionary<string, string>)value;
-
-                            foreach (string key in metadata.Keys)
-                            {
-                                newUrl = ApplyParameterToUrl(newUrl, string.Format("metadata[{0}]", key), metadata[key]);
-                            }
-                        }
-                        else if (property.PropertyType == typeof(StripeDateFilter))
-                        {
-                            var filter = (StripeDateFilter)value;
-
-                            if (filter.EqualTo.HasValue)
-                                newUrl = ApplyParameterToUrl(newUrl, attribute.PropertyName, filter.EqualTo.Value.ConvertDateTimeToEpoch().ToString());
-                            else
-                                if (filter.LessThan.HasValue)
-                                    newUrl = ApplyParameterToUrl(newUrl, attribute.PropertyName + "[lt]", filter.LessThan.Value.ConvertDateTimeToEpoch().ToString());
-
-                            if (filter.LessThanOrEqual.HasValue)
-                                newUrl = ApplyParameterToUrl(newUrl, attribute.PropertyName + "[lte]", filter.LessThanOrEqual.Value.ConvertDateTimeToEpoch().ToString());
-
-                            if (filter.GreaterThan.HasValue)
-                                newUrl = ApplyParameterToUrl(newUrl, attribute.PropertyName + "[gt]", filter.GreaterThan.Value.ConvertDateTimeToEpoch().ToString());
-
-                            if (filter.GreaterThanOrEqual.HasValue)
-                                newUrl = ApplyParameterToUrl(newUrl, attribute.PropertyName + "[gte]", filter.GreaterThanOrEqual.Value.ConvertDateTimeToEpoch().ToString());
-                        }
-                        else
-                        {
-                            newUrl = ApplyParameterToUrl(newUrl, attribute.PropertyName, value.ToString());
-                        }
-                    }
-                }
+                AddQueryStringProperties(queryStringProperties, Enumerable.Empty<string>(), obj);
             }
 
             if (service != null)
@@ -81,11 +42,104 @@ namespace Stripe
                         expandPropertyName = "data." + expandPropertyName;
                     }
 
-                    newUrl = ApplyParameterToUrl(newUrl, "expand[]", expandPropertyName);
+                    AddQueryStringProperty(queryStringProperties, null, "expand[]", expandPropertyName);
                 }
             }
 
-            return newUrl;
+            if (queryStringProperties.Count > 0)
+            {
+                var stringBuilder = new StringBuilder();
+                stringBuilder.Append(url);
+                stringBuilder.Append("?");
+                ToQueryString(stringBuilder, queryStringProperties);
+                return stringBuilder.ToString();
+            }
+            else
+            {
+                return url;                
+            }
+        }
+
+        private static void ToQueryString(StringBuilder stringBuilder, Dictionary<string, List<string>> properties)
+        {
+            var queryStrings = properties.SelectMany(kvp => kvp.Value.Select((v) => string.Format("{0}={1}", kvp.Key, v))).ToArray();
+            stringBuilder.Append(string.Join("&", queryStrings));
+        }
+
+        private static void AddQueryStringProperties(Dictionary<string, List<string>> queryStringProperties, IEnumerable<string> parents, object obj)
+        {
+            if (queryStringProperties == null) throw new ArgumentNullException("queryStringProperties");
+            if (parents == null) throw new ArgumentNullException("parents");
+
+            foreach (var property in obj.GetType().GetProperties(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance))
+            {
+                var value = property.GetValue(obj, null);
+                if (value == null) continue;
+                var valueType = value.GetType();
+
+                foreach (var attribute in property.GetCustomAttributes(typeof (JsonPropertyAttribute), false).Cast<JsonPropertyAttribute>())
+                {
+                    var dictionary = value as IDictionary<string, string>;
+                    if (dictionary != null)
+                    {
+                        foreach (string key in dictionary.Keys)
+                        {
+                            AddQueryStringProperty(queryStringProperties, parents.Union(new[] { attribute.PropertyName }), key, dictionary[key]);
+                        }
+                    }
+                    else if (value is StripeDateFilter)
+                    {
+                        var filter = (StripeDateFilter) value;
+
+                        if (filter.EqualTo.HasValue)
+                            AddQueryStringProperty(queryStringProperties, parents, attribute.PropertyName, filter.EqualTo.Value.ConvertDateTimeToEpoch().ToString());
+                        
+                        if (filter.LessThan.HasValue)
+                            AddQueryStringProperty(queryStringProperties, parents, attribute.PropertyName + "[lt]", filter.LessThan.Value.ConvertDateTimeToEpoch().ToString());
+
+                        if (filter.LessThanOrEqual.HasValue)
+                            AddQueryStringProperty(queryStringProperties, parents, attribute.PropertyName + "[lte]", filter.LessThanOrEqual.Value.ConvertDateTimeToEpoch().ToString());
+
+                        if (filter.GreaterThan.HasValue)
+                            AddQueryStringProperty(queryStringProperties, parents, attribute.PropertyName + "[gt]", filter.GreaterThan.Value.ConvertDateTimeToEpoch().ToString());
+
+                        if (filter.GreaterThanOrEqual.HasValue)
+                            AddQueryStringProperty(queryStringProperties,parents, attribute.PropertyName + "[gte]", filter.GreaterThanOrEqual.Value.ConvertDateTimeToEpoch().ToString());
+                    }
+                    else if (value is string || valueType.IsPrimitive)
+                    {
+                        AddQueryStringProperty(queryStringProperties, parents, attribute.PropertyName, value.ToString());
+                    }
+                    else
+                    {
+                        AddQueryStringProperties(queryStringProperties, parents.Union(new[] {attribute.PropertyName}), value);
+                    }
+                }
+            }
+        }
+
+        public static void AddQueryStringProperty(Dictionary<string, List<string>> queryStrings, IEnumerable<string> parents, string argument, string value)
+        {
+            if (parents != null)
+            {
+                int parentCount = 0;
+                var stringBuilder = new StringBuilder();
+                foreach (var parent in parents)
+                {
+                    parentCount++;
+                    stringBuilder.AppendFormat("{0}[", parent);
+                }
+                stringBuilder.Append(argument);
+                stringBuilder.Append(new string(']', parentCount));
+                argument = stringBuilder.ToString();
+            }
+
+            List<string> values;
+            if (!queryStrings.TryGetValue(argument, out values))
+            {
+                queryStrings.Add(argument, values = new List<string>());
+            }
+            values.Add(HttpUtility.UrlEncode(value));
         }
 
         public static string ApplyParameterToUrl(string url, string argument, string value)

--- a/src/Stripe/Infrastructure/ParameterBuilder.cs
+++ b/src/Stripe/Infrastructure/ParameterBuilder.cs
@@ -79,9 +79,20 @@ namespace Stripe
 
                 foreach (var attribute in property.GetCustomAttributes(typeof (JsonPropertyAttribute), false).Cast<JsonPropertyAttribute>())
                 {
-                    var dictionary = value as IDictionary<string, string>;
-                    if (dictionary != null)
+                    QueryStringParameterConverterAttribute converterAttrib = valueType.GetCustomAttributes(typeof(QueryStringParameterConverterAttribute), false).Cast<QueryStringParameterConverterAttribute>().FirstOrDefault();
+
+                    if (converterAttrib != null)
                     {
+                        var converter = converterAttrib.GetConverter();
+                        var convertedValue = converter.ConvertToQueryStringValue(value);
+                        if (convertedValue != null)
+                        {
+                            AddQueryStringProperty(queryStringProperties, parents, attribute.PropertyName, convertedValue);
+                        }
+                    }
+                    else if (value is IDictionary<string, string>)
+                    {
+                        var dictionary = (IDictionary<string, string>)value;
                         foreach (string key in dictionary.Keys)
                         {
                             AddQueryStringProperty(queryStringProperties, parents.Union(new[] { attribute.PropertyName }), key, dictionary[key]);

--- a/src/Stripe/Infrastructure/QueryStringParameterConverter.cs
+++ b/src/Stripe/Infrastructure/QueryStringParameterConverter.cs
@@ -1,0 +1,13 @@
+﻿namespace Stripe.Infrastructure
+{
+    internal abstract class QueryStringParameterConverter<T>
+        : IQueryStringParameterConverter
+    {
+        string IQueryStringParameterConverter.ConvertToQueryStringValue(object @object)
+        {
+            return ConvertToQueryStringValue((T) @object);
+        }
+
+        public abstract string ConvertToQueryStringValue(T @object);
+    }
+}

--- a/src/Stripe/Infrastructure/QueryStringParameterConverterAttribute.cs
+++ b/src/Stripe/Infrastructure/QueryStringParameterConverterAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Stripe.Infrastructure
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    internal class QueryStringParameterConverterAttribute : Attribute
+    {
+        private readonly Type _converterType;
+
+        public QueryStringParameterConverterAttribute(string typename)
+            : this(Type.GetType(typename))
+        {
+        }
+
+        public QueryStringParameterConverterAttribute(Type type)
+        {
+            if (type == null) throw new ArgumentNullException("type");
+            if (!typeof (IQueryStringParameterConverter).IsAssignableFrom(type))
+            {
+                throw new ArgumentException("Type must derive from IQueryStringParameterConverter");
+            }
+
+            _converterType = type;
+        }
+
+        public IQueryStringParameterConverter GetConverter()
+        {
+            return (IQueryStringParameterConverter)Activator.CreateInstance(_converterType);
+        }
+    }
+}

--- a/src/Stripe/Services/BankAccountOptions.cs
+++ b/src/Stripe/Services/BankAccountOptions.cs
@@ -2,15 +2,15 @@
 
 namespace Stripe
 {
-    public abstract class BankAccountOptions
+    public class BankAccountOptions
     {
-        [JsonProperty("bank_account[country]")]
-        public string BankAccountCountry { get; set; }
+        [JsonProperty("country")]
+        public string Country { get; set; }
 
-        [JsonProperty("bank_account[routing_number]")]
-        public string BankAccountRoutingNumber { get; set; }
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
 
-        [JsonProperty("bank_account[account_number]")]
-        public string BankAccountNumber { get; set; }
+        [JsonProperty("account_number")]
+        public string AccountNumber { get; set; }
     }
 }

--- a/src/Stripe/Services/BankAccountOptions.cs
+++ b/src/Stripe/Services/BankAccountOptions.cs
@@ -1,8 +1,13 @@
 ﻿using Newtonsoft.Json;
+using Stripe.Infrastructure;
 
 namespace Stripe
 {
-    public class BankAccountOptions
+    public interface IBankAccountOptions
+    {
+    }
+
+    public class BankAccountOptions : IBankAccountOptions
     {
         [JsonProperty("country")]
         public string Country { get; set; }
@@ -12,5 +17,20 @@ namespace Stripe
 
         [JsonProperty("account_number")]
         public string AccountNumber { get; set; }
+    }
+
+    [QueryStringParameterConverter(typeof(BankAccountTokenQueryStringParameterConverter))]
+    public class BankAccountToken : IBankAccountOptions
+    {
+        public string Token { get; set; }
+    }
+
+    internal class BankAccountTokenQueryStringParameterConverter
+        : QueryStringParameterConverter<BankAccountToken>
+    {
+        public override string ConvertToQueryStringValue(BankAccountToken @object)
+        {
+            return @object.Token;
+        }
     }
 }

--- a/src/Stripe/Services/Recipients/StripeRecipientCreateOptions.cs
+++ b/src/Stripe/Services/Recipients/StripeRecipientCreateOptions.cs
@@ -24,26 +24,32 @@ namespace Stripe
         [Obsolete("Use BankAccount.Country instead")]
         public string BankAccountCountry
         {
-            get { return BankAccount == null ? string.Empty : BankAccount.Country; }
-            set { (BankAccount ?? (BankAccount = new BankAccountOptions())).Country = value; }
+            get { return InternalBankAccountOptions == null ? string.Empty : InternalBankAccountOptions.Country; }
+            set { (InternalBankAccountOptions ?? (InternalBankAccountOptions = new BankAccountOptions())).Country = value; }
         }
 
         [Obsolete("Use BankAccount.RoutingNumber instead")]
         public string BankAccountRoutingNumber
         {
-            get { return BankAccount == null ? string.Empty : BankAccount.RoutingNumber; }
-            set { (BankAccount ?? (BankAccount = new BankAccountOptions())).RoutingNumber = value; }
+            get { return InternalBankAccountOptions == null ? string.Empty : InternalBankAccountOptions.RoutingNumber; }
+            set { (InternalBankAccountOptions ?? (InternalBankAccountOptions = new BankAccountOptions())).RoutingNumber = value; }
         }
 
         [Obsolete("Use BankAccount.AccountNumber instead")]
         public string BankAccountNumber
         {
-            get { return BankAccount == null ? string.Empty : BankAccount.AccountNumber; }
-            set { (BankAccount ?? (BankAccount = new BankAccountOptions())).AccountNumber = value; }
+            get { return InternalBankAccountOptions == null ? string.Empty : InternalBankAccountOptions.AccountNumber; }
+            set { (InternalBankAccountOptions ?? (InternalBankAccountOptions = new BankAccountOptions())).AccountNumber = value; }
+        }
+
+        private BankAccountOptions InternalBankAccountOptions
+        {
+            get { return BankAccount as BankAccountOptions; }
+            set { BankAccount = value; }
         }
 
         [JsonProperty("bank_account")]
-        public BankAccountOptions BankAccount { get; set; }
+        public IBankAccountOptions BankAccount { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe/Services/Recipients/StripeRecipientCreateOptions.cs
+++ b/src/Stripe/Services/Recipients/StripeRecipientCreateOptions.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeRecipientCreateOptions : BankAccountOptions
+    public class StripeRecipientCreateOptions
     {
         [JsonProperty("name")]
         public string Name { get; set; }
@@ -19,6 +20,30 @@ namespace Stripe
 
         [JsonProperty("description")]
         public string Description { get; set; }
+
+        [Obsolete("Use BankAccount.Country instead")]
+        public string BankAccountCountry
+        {
+            get { return BankAccount == null ? string.Empty : BankAccount.Country; }
+            set { (BankAccount ?? (BankAccount = new BankAccountOptions())).Country = value; }
+        }
+
+        [Obsolete("Use BankAccount.RoutingNumber instead")]
+        public string BankAccountRoutingNumber
+        {
+            get { return BankAccount == null ? string.Empty : BankAccount.RoutingNumber; }
+            set { (BankAccount ?? (BankAccount = new BankAccountOptions())).RoutingNumber = value; }
+        }
+
+        [Obsolete("Use BankAccount.AccountNumber instead")]
+        public string BankAccountNumber
+        {
+            get { return BankAccount == null ? string.Empty : BankAccount.AccountNumber; }
+            set { (BankAccount ?? (BankAccount = new BankAccountOptions())).AccountNumber = value; }
+        }
+
+        [JsonProperty("bank_account")]
+        public BankAccountOptions BankAccount { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe/Services/Recipients/StripeRecipientUpdateOptions.cs
+++ b/src/Stripe/Services/Recipients/StripeRecipientUpdateOptions.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeRecipientUpdateOptions : BankAccountOptions
+    public class StripeRecipientUpdateOptions
     {
         [JsonProperty("name")]
         public string Name { get; set; }
@@ -16,6 +17,30 @@ namespace Stripe
 
         [JsonProperty("description")]
         public string Description { get; set; }
+
+        [Obsolete("Use BankAccount.Country instead")]
+        public string BankAccountCountry
+        {
+            get { return BankAccount == null ? string.Empty : BankAccount.Country; }
+            set { (BankAccount ?? (BankAccount = new BankAccountOptions())).Country = value; }
+        }
+
+        [Obsolete("Use BankAccount.RoutingNumber instead")]
+        public string BankAccountRoutingNumber
+        {
+            get { return BankAccount == null ? string.Empty : BankAccount.RoutingNumber; }
+            set { (BankAccount ?? (BankAccount = new BankAccountOptions())).RoutingNumber = value; }
+        }
+
+        [Obsolete("Use BankAccount.AccountNumber instead")]
+        public string BankAccountNumber
+        {
+            get { return BankAccount == null ? string.Empty : BankAccount.AccountNumber; }
+            set { (BankAccount ?? (BankAccount = new BankAccountOptions())).AccountNumber = value; }
+        }
+
+        [JsonProperty("bank_account")]
+        public BankAccountOptions BankAccount { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe/Services/Recipients/StripeRecipientUpdateOptions.cs
+++ b/src/Stripe/Services/Recipients/StripeRecipientUpdateOptions.cs
@@ -21,26 +21,32 @@ namespace Stripe
         [Obsolete("Use BankAccount.Country instead")]
         public string BankAccountCountry
         {
-            get { return BankAccount == null ? string.Empty : BankAccount.Country; }
-            set { (BankAccount ?? (BankAccount = new BankAccountOptions())).Country = value; }
+            get { return InternalBankAccountOptions == null ? string.Empty : InternalBankAccountOptions.Country; }
+            set { (InternalBankAccountOptions ?? (InternalBankAccountOptions = new BankAccountOptions())).Country = value; }
         }
 
         [Obsolete("Use BankAccount.RoutingNumber instead")]
         public string BankAccountRoutingNumber
         {
-            get { return BankAccount == null ? string.Empty : BankAccount.RoutingNumber; }
-            set { (BankAccount ?? (BankAccount = new BankAccountOptions())).RoutingNumber = value; }
+            get { return InternalBankAccountOptions == null ? string.Empty : InternalBankAccountOptions.RoutingNumber; }
+            set { (InternalBankAccountOptions ?? (InternalBankAccountOptions = new BankAccountOptions())).RoutingNumber = value; }
         }
 
         [Obsolete("Use BankAccount.AccountNumber instead")]
         public string BankAccountNumber
         {
-            get { return BankAccount == null ? string.Empty : BankAccount.AccountNumber; }
-            set { (BankAccount ?? (BankAccount = new BankAccountOptions())).AccountNumber = value; }
+            get { return InternalBankAccountOptions == null ? string.Empty : InternalBankAccountOptions.AccountNumber; }
+            set { (InternalBankAccountOptions ?? (InternalBankAccountOptions = new BankAccountOptions())).AccountNumber = value; }
+        }
+
+        private BankAccountOptions InternalBankAccountOptions
+        {
+            get { return BankAccount as BankAccountOptions; }
+            set { BankAccount = value; }
         }
 
         [JsonProperty("bank_account")]
-        public BankAccountOptions BankAccount { get; set; }
+        public IBankAccountOptions BankAccount { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe/Stripe.csproj
+++ b/src/Stripe/Stripe.csproj
@@ -61,6 +61,9 @@
     <Compile Include="Entities\StripeObject.cs" />
     <Compile Include="Entities\StripeRecipientActiveAccount.cs" />
     <Compile Include="Infrastructure\ExpandableProperty.cs" />
+    <Compile Include="Infrastructure\IQueryStringParameterConverter.cs" />
+    <Compile Include="Infrastructure\QueryStringParameterConverter.cs" />
+    <Compile Include="Infrastructure\QueryStringParameterConverterAttribute.cs" />
     <Compile Include="Services\Balance\StripeBalanceTransactionListOptions.cs" />
     <Compile Include="Services\StripeDateFilter.cs" />
     <Compile Include="Entities\StripeApplicationFeeRefund.cs" />


### PR DESCRIPTION
This change includes the following modifications
* Updated the parameter builder to allow traversing of child objects (so you don't have to use inheritance to add re-usable child properties)
* Added a QueryStringParameterConverter to allow custom conversion of types to query string value (required for BankAccountToken, so it doesn't show as a sub-value)
* Added interface IBankAccountOption to allow both the original BankAccountOption (with account, routing, country) and BankAccountToken (with token from stripe.js).

*Note: Should not include any breaking changes since the original BankAccount values are piped to the new BankAccountOption class with an ObsoleteAttribute to push people to switch*

This provides a fix for Issue #182 