### PR TITLE
update stripe create transfers options to include recipient bank account and debit card options

### DIFF
--- a/src/Stripe/Services/Transfers/StripeTransferCreateOptions.cs
+++ b/src/Stripe/Services/Transfers/StripeTransferCreateOptions.cs
@@ -22,5 +22,11 @@ namespace Stripe
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("bank_account")]
+        public string BankAccountId { get; set; }
+
+        [JsonProperty("card")]
+        public string CardId { get; set; }
     }
 }


### PR DESCRIPTION
StripeCreateTransfersOptions do not include the "bank_account" and "card" property to support transferring to bank account OR debit cards. Update StripeCreateTransfersOptions properties to include these options.