### PR TITLE
Adding const strings for comparison with StripeTransfer.FailureCode

### DIFF
--- a/src/Stripe/Entities/StripeTransferFailureCodes.cs
+++ b/src/Stripe/Entities/StripeTransferFailureCodes.cs
@@ -1,0 +1,16 @@
+﻿namespace Stripe
+{
+    public static class StripeTransferFailureCodes
+    {
+        public const string InsufficientFunds = "insufficient_funds";
+        public const string AccountClosed = "account_closed";
+        public const string NoAccount = "no_account";
+        public const string InvalidAccountNumber = "invalid_account_number";
+        public const string DebitNotAuthorized = "debit_not_authorized";
+        public const string BankOwnershipChanged = "bank_ownership_changed";
+        public const string AccountFrozen = "account_frozen";
+        public const string CouldNotProcess = "could_not_process";
+        public const string BankAccountRestricted = "bank_account_restricted";
+        public const string InvalidCurrency = "invalid_currency";
+    }
+}

--- a/src/Stripe/Stripe.csproj
+++ b/src/Stripe/Stripe.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Entities\StripeFee.cs" />
     <Compile Include="Entities\StripeObject.cs" />
     <Compile Include="Entities\StripeRecipientActiveAccount.cs" />
+    <Compile Include="Entities\StripeTransferFailureCodes.cs" />
     <Compile Include="Infrastructure\ExpandableProperty.cs" />
     <Compile Include="Services\Balance\StripeBalanceTransactionListOptions.cs" />
     <Compile Include="Services\StripeDateFilter.cs" />

--- a/src/Stripe/Stripe3.5.csproj
+++ b/src/Stripe/Stripe3.5.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Entities\StripeList.cs" />
     <Compile Include="Entities\StripeObject.cs" />
     <Compile Include="Entities\StripeRecipientActiveAccount.cs" />
+    <Compile Include="Entities\StripeTransferFailureCodes.cs" />
     <Compile Include="Entities\StripeRefund.cs" />
     <Compile Include="Infrastructure\ExpandableProperty.cs" />
     <Compile Include="Services\Balance\StripeBalanceTransactionListOptions.cs" />


### PR DESCRIPTION
Using const strings allows for better backcompat (build-breaks instead of functional breaks) and helps avoid simple mistakes like typos.