### PR TITLE
Add support for the 'source' parameter when creating customers

### DIFF
--- a/src/Stripe.Tests/customers/when_creating_a_customer_with_a_source_token_id.cs
+++ b/src/Stripe.Tests/customers/when_creating_a_customer_with_a_source_token_id.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Machine.Specifications;
+
+namespace Stripe.Tests
+{
+    public class when_creating_a_customer_with_a_source_token_id
+    {
+        protected static StripeCustomerCreateOptions StripeCustomerCreateOptions;
+        protected static StripeCustomer StripeCustomer;
+        protected static StripePlan StripePlan;
+        protected static StripeCoupon StripeCoupon;
+        protected static StripeCard StripeCard;
+
+        private static StripeToken _stripeToken;
+        private static StripeCustomerService _stripeCustomerService;
+
+        Establish context = () =>
+        {
+            var _stripePlanService = new StripePlanService();
+            StripePlan = _stripePlanService.Create(test_data.stripe_plan_create_options.Valid());
+
+            var _stripeCouponService = new StripeCouponService();
+            StripeCoupon = _stripeCouponService.Create(test_data.stripe_coupon_create_options.Valid());
+
+            var stripeTokenService = new StripeTokenService();
+            _stripeToken = stripeTokenService.Create(test_data.stripe_token_create_options.Valid());
+
+            _stripeCustomerService = new StripeCustomerService();
+            StripeCustomerCreateOptions = test_data.stripe_customer_create_options.ValidSourceTokenId(_stripeToken.Id);
+        };
+
+        Because of = () =>
+        {
+            StripeCustomer = _stripeCustomerService.Create(StripeCustomerCreateOptions);
+
+            StripeCard = _stripeToken.StripeCard;
+        };
+
+        Behaves_like<customer_behaviors> behaviors;
+
+        It should_have_the_source_token_id = () =>
+            StripeCustomerCreateOptions.SourceTokenId.ShouldNotBeNull();
+    }
+}

--- a/src/Stripe/Services/Customers/StripeCustomerCreateOptions.cs
+++ b/src/Stripe/Services/Customers/StripeCustomerCreateOptions.cs
@@ -31,6 +31,9 @@ namespace Stripe
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        [JsonProperty("source")]
+        public string SourceTokenId { get; set; }
+
         public DateTime? TrialEnd { get; set; }
 
         [JsonProperty("trial_end")]


### PR DESCRIPTION
As per the [Saving credit card details for later](https://stripe.com/docs/tutorials/charges#saving-credit-card-details-for-later) article on the docs, the `source` parameter is required when creating a customer so that a customer can be both charged and saved to an internal database using a single Stripe.JS/Checkout token.

[API Docs for "source"](https://stripe.com/docs/api#create_customer)

Here's a C# version of the code in the linked article, using the new `SourceTokenId` included.
```c#
// Create a Customer
var customer = _customerService.Create(new StripeCustomerCreateOptions
{
    SourceTokenId = tokenId, // tokenId retrieved from Stripe.JS/Checkout
    Description = "payinguser@example.com"
});

// Charge the Customer instead of the card
var charge = _chargeService.Create(new StripeChargeCreateOptions
{
    CustomerId = customer.Id,
    Amount = 1000, // in cents
    Currency = "usd"
});

// Save the customer ID in your database so you can use it later
CustomerDb.Add("test@email.com", customer.Id);

// Later...
var customerId = CustomerDb.GetStripeCustomerId("test@email.com");
var chargeLater = _chargeService.Create(new StripeChargeCreateOptions
{
    CustomerId = customer.Id,
    Amount = 1500, // $15.00 this time
    Currency = "usd"
});
```

I've *attempted* to add unit tests for this. I'm sorry if they don't work, but I'm not familiar with writing MSpec tests,