### PR TITLE
Adding Dispute to StripeCharge

### DIFF
--- a/src/Stripe.Tests/Stripe.Tests.csproj
+++ b/src/Stripe.Tests/Stripe.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="charges\charge_behaviors.cs" />
     <Compile Include="charges\when_capturing_a_charge_with_a_card.cs" />
     <Compile Include="charges\when_creating_a_charge_with_a_customer_expanded.cs" />
+    <Compile Include="charges\when_getting_a_disputed_charge.cs" />
     <Compile Include="charges\when_listing_charges_by_date.cs" />
     <Compile Include="charges\when_listing_charges_with_expanded_properties.cs" />
     <Compile Include="charges\when_listing_charges_with_paging.cs" />

--- a/src/Stripe.Tests/charges/test_data/stripe_charge_create_options.cs
+++ b/src/Stripe.Tests/charges/test_data/stripe_charge_create_options.cs
@@ -34,6 +34,37 @@ namespace Stripe.Tests.test_data
             };
         }
 
+        public static StripeChargeCreateOptions DisputedCard()
+        {
+            var cardOptions = new StripeCreditCardOptions()
+            {
+                CardAddressCountry = "US",
+                CardAddressLine1 = "24 Beef Flank St",
+                CardAddressLine2 = "Apt 24",
+                CardAddressCity = "BIGGIE",
+                CardAddressState = "NC",
+                CardAddressZip = "27617",
+                CardCvc = "1223",
+                CardExpirationMonth = "10",
+                CardExpirationYear = "2021",
+                CardName = "Joe Meatballs",
+                CardNumber = "4000000000000259",
+            };
+
+            return new StripeChargeCreateOptions()
+            {
+                Card = cardOptions,
+                Description = "Joe Meatball Charge",
+                Amount = 5153,
+                Currency = "usd",
+                Metadata = new Dictionary<string, string>
+                {
+                    { "A", "Value-A" },
+                    { "B", "Value-B" }
+                }
+            };
+        }
+
         public static StripeChargeCreateOptions InvalidCard()
         {
             var cardOptions = new StripeCreditCardOptions()

--- a/src/Stripe.Tests/charges/when_getting_a_disputed_charge.cs
+++ b/src/Stripe.Tests/charges/when_getting_a_disputed_charge.cs
@@ -1,0 +1,42 @@
+﻿using System.Diagnostics;
+using System.Threading;
+using Machine.Specifications;
+
+namespace Stripe.Tests
+{
+    public class when_getting_a_disputed_charge
+    {
+        protected static StripeChargeCreateOptions StripeChargeCreateOptions;
+        protected static StripeCharge StripeCharge;
+        protected static StripeCard StripeCard;
+
+        private static StripeChargeService _stripeChargeService;
+        private static string _createdStripeChargeId;
+
+        Establish context = () =>
+        {
+            _stripeChargeService = new StripeChargeService();
+            StripeChargeCreateOptions = test_data.stripe_charge_create_options.DisputedCard();
+
+            var stripeCharge = _stripeChargeService.Create(StripeChargeCreateOptions);
+            _createdStripeChargeId = stripeCharge.Id;
+        };
+
+        Because of = () =>
+        {
+            var stopwatch = Stopwatch.StartNew();
+            do
+            {
+                StripeCharge = _stripeChargeService.Get(_createdStripeChargeId);
+                StripeCard = StripeCharge.StripeCard;
+                if (StripeCharge.Dispute != null) break;
+                Thread.Sleep(500);
+            } while (stopwatch.ElapsedMilliseconds < 10000);
+        };
+
+        Behaves_like<charge_behaviors> behaviors;
+
+        It should_have_dispute_defined = () =>
+            StripeCharge.Dispute.ShouldNotBeNull();
+    }
+}

--- a/src/Stripe/Entities/StripeCharge.cs
+++ b/src/Stripe/Entities/StripeCharge.cs
@@ -72,7 +72,8 @@ namespace Stripe
         [JsonProperty("description")]
         public string Description { get; set; }
 
-        // todo: hash, dispute object
+        [JsonProperty("dispute")]
+        public StripeDispute Dispute { get; set; }
 
         [JsonProperty("failure_code")]
         public string FailureCode { get; set; }


### PR DESCRIPTION
There was a TODO in the StripeCharge to add the dispute object, which I've added plus a unit test (need to wait for the dispute to be processed, which is why the loop in the test)