### PR TITLE
ACH/Bank Account Support

### DIFF
--- a/src/Stripe/Entities/StripeBankAccount.cs
+++ b/src/Stripe/Entities/StripeBankAccount.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
+using Stripe.Infrastructure;
 
 namespace Stripe
 {
@@ -26,7 +27,26 @@ namespace Stripe
         [JsonProperty("fingerprint")]
         public string Fingerprint { get; set; }
 
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
+
+        #region Expandable Customer
+        public string CustomerId { get; set; }
+
+        [JsonIgnore]
+        public StripeCustomer Customer { get; set; }
+
+        [JsonProperty("customer")]
+        internal object InternalCustomer
+        {
+            set
+            {
+                ExpandableProperty<StripeCustomer>.Map(value, s => CustomerId = s, o => Customer = o);
+            }
+        }
+        #endregion
     }
 }

--- a/src/Stripe/Entities/StripeBankAccountList.cs
+++ b/src/Stripe/Entities/StripeBankAccountList.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeBankAccountList
+    {
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        [JsonProperty("data")]
+        public List<StripeBankAccount> StripBankAccounts { get; set; }
+
+        [JsonProperty("has_more")]
+        public bool HasMore { get; set; }
+
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        [JsonProperty("total_count")]
+        public int TotalCount { get; set; }
+    }
+}

--- a/src/Stripe/Entities/StripeCustomer.cs
+++ b/src/Stripe/Entities/StripeCustomer.cs
@@ -17,6 +17,9 @@ namespace Stripe
         [JsonProperty("cards")]
         public StripeCardList StripeCardList { get; set; }
 
+        [JsonProperty("bank_accounts")]
+        public StripeBankAccountList StripeBankAccountList { get; set; }
+
         [JsonProperty("created")]
         [JsonConverter(typeof(StripeDateTimeConverter))]
         public DateTime Created { get; set; }
@@ -38,6 +41,24 @@ namespace Stripe
                 ExpandableProperty<StripeCard>.Map(value, s => StripeDefaultCardId = s, o => StripeDefaultCard = o);
             }
         }
+
+        public string StripeDefaultBankAccountId { get; set; }
+        public StripeBankAccount StripeDefaultBankAccount { get; set; }
+
+        [JsonProperty("default_bank_account")]
+        internal object InternalDefaultBankAccount
+        {
+            set
+            {
+                ExpandableProperty<StripeBankAccount>.Map( value, s => StripeDefaultBankAccountId = s, o => StripeDefaultBankAccount = o );
+            }
+        }
+
+        [JsonProperty("default_source_type")]
+        public string DefaultSourceType { get; set; }
+
+        [JsonProperty("default_source")]
+        public string DefaultSourceId { get; set; }
 
         [JsonProperty("delinquent")]
         public bool Delinquent { get; set; }

--- a/src/Stripe/Infrastructure/Urls.cs
+++ b/src/Stripe/Infrastructure/Urls.cs
@@ -57,6 +57,11 @@
             get { return BaseUrl + "/customers/{0}/cards"; }
         }
 
+        public static string BankAccounts
+        {
+            get { return BaseUrl + "/customers/{0}/bank_accounts"; }
+        }
+
         public static string Events
         {
             get { return BaseUrl + "/events"; }

--- a/src/Stripe/Services/BankAccounts/StripeBankAccountCreateOptions.cs
+++ b/src/Stripe/Services/BankAccounts/StripeBankAccountCreateOptions.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeBankAccountCreateOptions
+    {
+        [JsonProperty("bank_account")]
+        public StripeBankAccountOptions BankAccount { get; set; }
+    }
+}

--- a/src/Stripe/Services/BankAccounts/StripeBankAccountService.cs
+++ b/src/Stripe/Services/BankAccounts/StripeBankAccountService.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+
+namespace Stripe
+{
+    public class StripeBankAccountService : StripeService
+    {
+        public StripeBankAccountService(string apiKey = null) : base(apiKey) { }
+
+        public bool ExpandCustomer { get; set; }
+        public bool ExpandRecipient { get; set; }
+
+        public virtual StripeBankAccount Create(string customerId, StripeBankAccountCreateOptions createOptions)
+        {
+            var url = string.Format(Urls.BankAccounts, customerId);
+            url = this.ApplyAllParameters(createOptions, url, false);
+
+            var response = Requestor.PostString(url, ApiKey);
+
+            return Mapper<StripeBankAccount>.MapFromJson(response);
+        }
+
+        public virtual StripeBankAccount Get(string customerId, string bankAccountId)
+        {
+            var customerUrl = string.Format(Urls.BankAccounts, customerId);
+            var url = string.Format("{0}/{1}", customerUrl, bankAccountId);
+            url = this.ApplyAllParameters(null, url, false);
+
+            var response = Requestor.GetString(url, ApiKey);
+
+            return Mapper<StripeBankAccount>.MapFromJson(response);
+        }
+
+        public virtual StripeBankAccount Update(string customerId, string bankAccountId, StripeBankAccountUpdateOptions updateOptions)
+        {
+            var customerUrl = string.Format(Urls.BankAccounts, customerId);
+            var url = string.Format("{0}/{1}", customerUrl, bankAccountId);
+            url = this.ApplyAllParameters(updateOptions, url, false);
+
+            var response = Requestor.PostString(url, ApiKey);
+
+            return Mapper<StripeBankAccount>.MapFromJson(response);
+        }
+
+        public virtual StripeBankAccount Verify(string customerId, string bankAccountId, StripeBankAccountVerifyOptions verifyOptions)
+        {
+            var customerUrl = string.Format(Urls.BankAccounts, customerId);
+            var url = string.Format("{0}/{1}/verify", customerUrl, bankAccountId);
+            url = this.ApplyAllParameters(verifyOptions, url, false);
+
+            var response = Requestor.PostString(url, ApiKey);
+
+            return Mapper<StripeBankAccount>.MapFromJson(response);
+        }
+
+        public virtual void Delete(string customerId, string bankAccountId)
+        {
+            var customerUrl = string.Format(Urls.BankAccounts, customerId);
+            var url = string.Format("{0}/{1}", customerUrl, bankAccountId);
+
+            Requestor.Delete(url, ApiKey);
+        }
+
+        public virtual IEnumerable<StripeBankAccount> List(string customerId, StripeListOptions listOptions = null)
+        {
+            var url = string.Format(Urls.BankAccounts, customerId);
+            url = this.ApplyAllParameters(listOptions, url, true);
+
+            var response = Requestor.GetString(url, ApiKey);
+
+            return Mapper<StripeBankAccount>.MapCollectionFromJson(response);
+        }
+    }
+}

--- a/src/Stripe/Services/BankAccounts/StripeBankAccountUpdateOptions.cs
+++ b/src/Stripe/Services/BankAccounts/StripeBankAccountUpdateOptions.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeBankAccountUpdateOptions
+    {
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+    }
+}

--- a/src/Stripe/Services/BankAccounts/StripeBankAccountVerifyOptions.cs
+++ b/src/Stripe/Services/BankAccounts/StripeBankAccountVerifyOptions.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeBankAccountVerifyOptions
+    {
+        [JsonProperty("amounts[]")]
+        public int Amount1 { get; set; }
+
+        [JsonProperty("amounts[]")]
+        public int Amount2 { get; set; }
+    }
+}

--- a/src/Stripe/Services/Customers/StripeCustomerService.cs
+++ b/src/Stripe/Services/Customers/StripeCustomerService.cs
@@ -7,6 +7,7 @@ namespace Stripe
         public StripeCustomerService(string apiKey = null) : base(apiKey) { }
 
         public bool ExpandDefaultCard { get; set; }
+        public bool ExpandDefaultBankAccount { get; set; }
 
         public virtual StripeCustomer Create(StripeCustomerCreateOptions createOptions)
         {

--- a/src/Stripe/Services/Tokens/StripeTokenCreateOptions.cs
+++ b/src/Stripe/Services/Tokens/StripeTokenCreateOptions.cs
@@ -9,5 +9,8 @@ namespace Stripe
 
         [JsonProperty("card")]
         public StripeCreditCardOptions Card { get; set; }
+
+        [JsonProperty("bank_account")]
+        public StripeBankAccountOptions BankAccount { get; set; }
     }
 }

--- a/src/Stripe/Stripe.csproj
+++ b/src/Stripe/Stripe.csproj
@@ -56,11 +56,16 @@
     <Compile Include="Entities\StripeRefund.cs" />
     <Compile Include="Entities\StripeBankAccount.cs" />
     <Compile Include="Entities\StripeBalanceTransaction.cs" />
+    <Compile Include="Entities\StripeBankAccountList.cs" />
     <Compile Include="Entities\StripeFee.cs" />
     <Compile Include="Entities\StripeObject.cs" />
     <Compile Include="Entities\StripeRecipientActiveAccount.cs" />
     <Compile Include="Infrastructure\ExpandableProperty.cs" />
     <Compile Include="Services\Balance\StripeBalanceTransactionListOptions.cs" />
+    <Compile Include="Services\BankAccounts\StripeBankAccountCreateOptions.cs" />
+    <Compile Include="Services\BankAccounts\StripeBankAccountService.cs" />
+    <Compile Include="Services\BankAccounts\StripeBankAccountVerifyOptions.cs" />
+    <Compile Include="Services\BankAccounts\StripeBankAccountUpdateOptions.cs" />
     <Compile Include="Services\StripeDateFilter.cs" />
     <Compile Include="Entities\StripeApplicationFeeRefund.cs" />
     <Compile Include="Entities\StripeApplicationFee.cs" />
@@ -150,6 +155,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/src/Stripe/Stripe3.5.csproj
+++ b/src/Stripe/Stripe3.5.csproj
@@ -71,6 +71,7 @@
     </Compile>
     <Compile Include="Entities\StripeBalanceTransaction.cs" />
     <Compile Include="Entities\StripeBankAccount.cs" />
+    <Compile Include="Entities\StripeBankAccountList.cs" />
     <Compile Include="Entities\StripeFee.cs" />
     <Compile Include="Entities\StripeInvoiceLineItem.cs" />
     <Compile Include="Entities\StripeList.cs" />
@@ -79,6 +80,10 @@
     <Compile Include="Entities\StripeRefund.cs" />
     <Compile Include="Infrastructure\ExpandableProperty.cs" />
     <Compile Include="Services\Balance\StripeBalanceTransactionListOptions.cs" />
+    <Compile Include="Services\BankAccounts\StripeBankAccountCreateOptions.cs" />
+    <Compile Include="Services\BankAccounts\StripeBankAccountService.cs" />
+    <Compile Include="Services\BankAccounts\StripeBankAccountUpdateOptions.cs" />
+    <Compile Include="Services\BankAccounts\StripeBankAccountVerifyOptions.cs" />
     <Compile Include="Services\StripeBankAccountOptions.cs" />
     <Compile Include="Services\StripeCreditCardOptions.cs" />
     <Compile Include="Services\StripeDateFilter.cs" />


### PR DESCRIPTION
Adds ACH bank account services and properties. We've been using these additions with success on our product that uses ACH subscription-based billing for customers.

Note that not all endpoints are implemented since the Stripe.net library has not been updated to support the new customer/charges "sources" Stripe APIs for cards and bank accounts (see https://stripe.com/docs/upgrades 2015-02-18 update).

Stripe ACH docs for this implementation:
- https://stripe.com/docs/guides/ach-beta
- https://gist.github.com/raycmorgan/166e899cbb359768ad29

references issue #247

Let me know if there are any changes you would like to see.