### PR TITLE
Add decline_code to StripeError.cs

### DIFF
--- a/src/Stripe/Entities/StripeError.cs
+++ b/src/Stripe/Entities/StripeError.cs
@@ -24,5 +24,8 @@ namespace Stripe
 
         [JsonProperty("charge")]
         public string ChargeId { get; set; }
+        
+        [JsonProperty("decline_code")]
+        public string DeclineCode { get; set; }
     }
 }


### PR DESCRIPTION
From Stripe documentation, API returns decline_code when charge is fraudulent. I have added a property called DeclineCode with JsonProperty decline_code to StripeError.cs

Below text is from Stripe page https://stripe.com/docs/fraud
Getting information on charges Stripe thinks are fraudulent

If Stripe believes a payment is fraudulent, we will block the charge creation attempt. The error hash returned by the API will have a decline_code key with a value of fraudulent:
```
curl https://api.stripe.com/v1/charges \
   -u sk_test_S3lkd9NwpxSzDXDwGJUwAQ2D: \
   -d card=tok_51ZM3BwtekpEyl \
   -d amount=2000 \
   -d currency=usd

{
  "error": {
    "message": "Your card was declined.",
    "type": "card_error",
    "code": "card_declined",
    "decline_code": "fraudulent",
    "charge": "ch_5IZNUkTDe6ir9d"
  }
}
```
