### PR TITLE
Parameter Support for Upcoming Invoices

### DIFF
--- a/src/Stripe.Tests/invoices/when_getting_an_upcoming_invoice.cs
+++ b/src/Stripe.Tests/invoices/when_getting_an_upcoming_invoice.cs
@@ -34,7 +34,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeInvoice = _stripeInvoiceService.Upcoming(_stripeCustomer.Id);
+            _stripeInvoice = _stripeInvoiceService.Upcoming( _stripeCustomer.Id, null );
         
         It should_have_a_valid_id = () =>
             _stripeInvoice.Id.ShouldBeNull();

--- a/src/Stripe/Services/Invoices/StripeInvoiceService.cs
+++ b/src/Stripe/Services/Invoices/StripeInvoiceService.cs
@@ -20,18 +20,16 @@ namespace Stripe
             return Mapper<StripeInvoice>.MapFromJson(response);
         }
 
-        public virtual StripeInvoice Upcoming(string customerId, string subscriptionId = null)
+        public virtual StripeInvoice Upcoming( string customerId, StripeUpcomingInvoiceOptions options )
         {
-            var url = string.Format("{0}/{1}", Urls.Invoices, "upcoming");
+           var url = string.Format( "{0}/{1}", Urls.Invoices, "upcoming" );
 
-            url = ParameterBuilder.ApplyParameterToUrl(url, "customer", customerId);
+           url = ParameterBuilder.ApplyParameterToUrl( url, "customer", customerId );
+           url = this.ApplyAllParameters( options, url, false );
 
-            if(!String.IsNullOrEmpty(subscriptionId))
-                url = ParameterBuilder.ApplyParameterToUrl(url, "subscription", subscriptionId);
+           var response = Requestor.GetString( url, ApiKey );
 
-            var response = Requestor.GetString(url, ApiKey);
-
-            return Mapper<StripeInvoice>.MapFromJson(response);
+           return Mapper<StripeInvoice>.MapFromJson( response );
         }
 
         public virtual StripeInvoice Update(string invoiceId, StripeInvoiceUpdateOptions updateOptions)

--- a/src/Stripe/Services/Invoices/StripeUpcomingInvoiceOptions.cs
+++ b/src/Stripe/Services/Invoices/StripeUpcomingInvoiceOptions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Newtonsoft.Json;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+   public class StripeUpcomingInvoiceOptions
+   {
+      [JsonProperty( "subscription" )]
+      public string SubscriptionId { get; set; }
+
+      [JsonProperty( "subscription_plan" )]
+      public string PlanId { get; set; }
+
+      [JsonProperty( "subscription_quantity" )]
+      public int? Quantity { get; set; }
+
+      public DateTime? TrialEnd { get; set; }
+
+      [JsonProperty( "subscription_trial_end" )]
+      internal long? TrialEndInternal
+      {
+         get
+         {
+            if ( !TrialEnd.HasValue )
+               return null;
+
+            return EpochTime.ConvertDateTimeToEpoch( TrialEnd.Value );
+         }
+      }
+
+      [JsonProperty( "subscription_prorate" )]
+      public bool? Prorate { get; set; }
+
+      public DateTime? ProrationDate { get; set; }
+
+      [JsonProperty( "subscription_proration_date" )]
+      internal long? ProrationDateInternal
+      {
+         get
+         {
+            if ( !ProrationDate.HasValue )
+               return null;
+
+            return EpochTime.ConvertDateTimeToEpoch( ProrationDate.Value );
+         }
+      }
+   }
+}

--- a/src/Stripe/Stripe.csproj
+++ b/src/Stripe/Stripe.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Constants\StripeRefundReasons.cs" />
     <Compile Include="Infrastructure\ExpandableProperty.cs" />
     <Compile Include="Services\Balance\StripeBalanceTransactionListOptions.cs" />
+    <Compile Include="Services\Invoices\StripeUpcomingInvoiceOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundCreateOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundService.cs" />
     <Compile Include="Services\Refunds\StripeRefundUpdateOptions.cs" />

--- a/src/Stripe/Stripe3.5.csproj
+++ b/src/Stripe/Stripe3.5.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Entities\StripeTransferReversal.cs" />
     <Compile Include="Infrastructure\ExpandableProperty.cs" />
     <Compile Include="Services\Balance\StripeBalanceTransactionListOptions.cs" />
+    <Compile Include="Services\Invoices\StripeUpcomingInvoiceOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundCreateOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundService.cs" />
     <Compile Include="Services\Refunds\StripeRefundUpdateOptions.cs" />


### PR DESCRIPTION
- Added `StripeUpcomingInvoiceOptions` object for passing more parameters to `StripeInvoiceService.Upcoming()` method. Allows you to preview changes to a user's subscription without actually having to modify it. [See Docs](https://stripe.com/docs/api#retrieve_customer_invoice).
    - previously could only get upcoming invoice for all of a stripe customer's subscriptions, or only for a specific subscription Id.

- Does not explicitly enforce rules outlined in the docs
   -  e.g. - if subscription_proration_date is specified, subscription_proration cannot be set to false, etc...