### PR TITLE
Set StripeSourceOptions.Object from TokenId instead of requiring specification

### DIFF
--- a/src/Stripe.Tests/customers/test_data/stripe_customer_create_options.cs
+++ b/src/Stripe.Tests/customers/test_data/stripe_customer_create_options.cs
@@ -9,7 +9,6 @@ namespace Stripe.Tests.test_data
         {
             var cardOptions = new StripeSourceOptions()
             {
-                Object = "card",
                 AddressCountry = "US",
                 AddressLine1 = "234 Bacon St",
                 AddressLine2 = "Apt 1",

--- a/src/Stripe/Services/StripeSourceOptions.cs
+++ b/src/Stripe/Services/StripeSourceOptions.cs
@@ -10,7 +10,13 @@ namespace Stripe
         public string TokenId { get; set; }
 
         [JsonProperty("source[object]")]
-        public string Object { get; set; }
+        internal string Object
+        {
+            get
+            {
+                return (String.IsNullOrEmpty(TokenId)) ? "card" : null;
+            }
+        }
 
         [JsonProperty("source[number]")]
         public string Number { get; set; }


### PR DESCRIPTION
Hey @jaymedavis 
I worked recently from the readme.md and noticed that specification of the Object property wasn't included in the examples.

It looks like this was recently added to address changes in Stripe's API - since only cards can (apparently) be specified on charges / customer accounts without a token, this seemed to be a good change to automatically determine the Object value if the token wasn't present.

Let me know if you have any concerns about this.  All tests passed as well after this change.