### PR TITLE
Ability to delete discounts that have been applied to customers and subscriptions

### DIFF
--- a/src/Stripe/Services/Customers/StripeCustomerService.cs
+++ b/src/Stripe/Services/Customers/StripeCustomerService.cs
@@ -63,5 +63,14 @@ namespace Stripe
 
             return Mapper<StripeCustomer>.MapCollectionFromJson(response);
         }
+
+        public virtual void DeleteDiscount(string customerId, StripeRequestOptions requestOptions = null)
+        {
+            requestOptions = SetupRequestOptions(requestOptions);
+
+            var url = string.Format(Urls.Customers + "/{0}/discount", customerId);
+
+            Requestor.Delete(url, requestOptions);
+        }
     }
 }

--- a/src/Stripe/Services/Subscriptions/StripeSubscriptionService.cs
+++ b/src/Stripe/Services/Subscriptions/StripeSubscriptionService.cs
@@ -69,5 +69,14 @@ namespace Stripe
 
             return Mapper<StripeSubscription>.MapCollectionFromJson(response);
         }
+
+        public virtual void DeleteDiscount(string customerId, string subscriptionId, StripeRequestOptions requestOptions = null)
+        {
+            requestOptions = SetupRequestOptions(requestOptions);
+
+            var url = string.Format(Urls.Subscriptions + "/{1}/discount", customerId, subscriptionId);
+
+            Requestor.Delete(url, requestOptions);
+        }
     }
 }


### PR DESCRIPTION
Currently, there is no way to remove discounts that have been applied to customers or subscriptions.

Stipe has the endpoint implemented already, shown here: https://stripe.com/docs/api#delete_discount

This pull request adds these two endpoints to the respective services as the "DeleteDiscount" method.