### PR TITLE
Added the ability to add/update coupon Metadata

### DIFF
--- a/src/Stripe/Services/Coupons/StripeCouponCreateOptions.cs
+++ b/src/Stripe/Services/Coupons/StripeCouponCreateOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Stripe.Infrastructure;
 
@@ -39,5 +40,8 @@ namespace Stripe
                 return EpochTime.ConvertDateTimeToEpoch(RedeemBy.Value);
             }
         }
+
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/src/Stripe/Services/Coupons/StripeCouponService.cs
+++ b/src/Stripe/Services/Coupons/StripeCouponService.cs
@@ -17,6 +17,19 @@ namespace Stripe
             return Mapper<StripeCoupon>.MapFromJson(response);
         }
 
+        public virtual StripeCoupon Update(string couponId, StripeCouponUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
+        {
+            requestOptions = SetupRequestOptions(requestOptions);
+
+            var url = string.Format("{0}/{1}", Urls.Coupons, couponId);
+            url = this.ApplyAllParameters(updateOptions, url, false);
+
+            var response = Requestor.PostString(url, requestOptions);
+
+            return Mapper<StripeCoupon>.MapFromJson(response);
+        }
+
+
         public virtual StripeCoupon Get(string couponId, StripeRequestOptions requestOptions = null)
         {
             requestOptions = SetupRequestOptions(requestOptions);

--- a/src/Stripe/Services/Coupons/StripeCouponUpdateOptions.cs
+++ b/src/Stripe/Services/Coupons/StripeCouponUpdateOptions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+    public class StripeCouponUpdateOptions
+    {
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+    }
+}

--- a/src/Stripe/Stripe.csproj
+++ b/src/Stripe/Stripe.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Constants\StripeRefundReasons.cs" />
     <Compile Include="Infrastructure\ExpandableProperty.cs" />
     <Compile Include="Services\Balance\StripeBalanceTransactionListOptions.cs" />
+    <Compile Include="Services\Coupons\StripeCouponUpdateOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundCreateOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundService.cs" />
     <Compile Include="Services\Refunds\StripeRefundUpdateOptions.cs" />

--- a/src/Stripe/Stripe3.5.csproj
+++ b/src/Stripe/Stripe3.5.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Entities\StripeTransferReversal.cs" />
     <Compile Include="Infrastructure\ExpandableProperty.cs" />
     <Compile Include="Services\Balance\StripeBalanceTransactionListOptions.cs" />
+    <Compile Include="Services\Coupons\StripeCouponUpdateOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundCreateOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundService.cs" />
     <Compile Include="Services\Refunds\StripeRefundUpdateOptions.cs" />


### PR DESCRIPTION
Stripe allows the addition of Metadata to coupons, which is very useful for storing descriptions or other information related to coupons. The current Stripe.NET API didn't allow for Metadata (simply Key-Value pairs), so this patch extends that. 