### PR TITLE
Added update method for charges

### DIFF
--- a/src/Stripe.Tests/Stripe.Tests.csproj
+++ b/src/Stripe.Tests/Stripe.Tests.csproj
@@ -69,6 +69,8 @@
     <Compile Include="balance\when_listing_balancetransactions.cs" />
     <Compile Include="balance\when_listing_balancetransactions_for_charge.cs" />
     <Compile Include="balance\when_retrieving_a_balance.cs" />
+    <Compile Include="charges\test_data\stripe_charge_update_options.cs" />
+    <Compile Include="charges\when_updating_a_charge.cs" />
     <Compile Include="idempotency\when_creating_a_charge_with_a_card_and_idempotency_key.cs" />
     <Compile Include="charges\charge_behaviors.cs" />
     <Compile Include="charges\when_capturing_a_charge_with_a_card.cs" />

--- a/src/Stripe.Tests/charges/test_data/stripe_charge_update_options.cs
+++ b/src/Stripe.Tests/charges/test_data/stripe_charge_update_options.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace Stripe.Tests.test_data
+{
+    public static class stripe_charge_update_options
+    {
+        public static StripeChargeUpdateOptions Valid()
+        {
+            var stripeChargeUpdateOptions = new StripeChargeUpdateOptions
+            {
+                Description = "Gangster Pancakes (syrup@og.com)",
+                Metadata = new Dictionary<string, string>
+                {
+                    { "A", "Value-A" },
+                    { "B", "Value-B" },
+                    { "C", "Value-C" }
+                },
+                ReceiptEmail = "syrup@og.com"
+            };
+
+            return stripeChargeUpdateOptions;
+        }
+    }
+}

--- a/src/Stripe.Tests/charges/when_updating_a_charge.cs
+++ b/src/Stripe.Tests/charges/when_updating_a_charge.cs
@@ -1,0 +1,37 @@
+﻿using Machine.Specifications;
+
+namespace Stripe.Tests
+{
+    public class when_updating_a_charge
+    {
+        private static StripeChargeUpdateOptions StripeChargeUpdateOptions;
+        private static StripeCharge _stripeCharge;
+        private static StripeChargeService _stripeChargeService;
+        private static string _createdStripeChargeId;
+
+        Establish context = () =>
+        {
+            _stripeChargeService = new StripeChargeService();
+
+            var stripeCustomer = _stripeChargeService.Create(test_data.stripe_charge_create_options.ValidCard());
+            _createdStripeChargeId = stripeCustomer.Id;
+
+            StripeChargeUpdateOptions = test_data.stripe_charge_update_options.Valid();
+        };
+
+        Because of = () =>
+            _stripeCharge = _stripeChargeService.Update(_createdStripeChargeId, StripeChargeUpdateOptions);
+
+        It should_have_the_correct_description = () =>
+            _stripeCharge.Description.ShouldEqual(StripeChargeUpdateOptions.Description);
+
+        It should_have_metadata = () =>
+            _stripeCharge.Metadata.Count.ShouldBeGreaterThan(0);
+
+        It should_have_the_correct_metadata = () =>
+            _stripeCharge.Metadata.ShouldContainOnly(StripeChargeUpdateOptions.Metadata);
+
+        It should_have_the_correct_receipt_email = () =>
+            _stripeCharge.ReceiptEmail.ShouldEqual(StripeChargeUpdateOptions.ReceiptEmail);
+    }
+}

--- a/src/Stripe/Services/Charges/StripeChargeService.cs
+++ b/src/Stripe/Services/Charges/StripeChargeService.cs
@@ -22,6 +22,18 @@ namespace Stripe
             return Mapper<StripeCharge>.MapFromJson(response);
         }
 
+        public virtual StripeCharge Update(string chargeId, StripeChargeUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
+        {
+            requestOptions = SetupRequestOptions(requestOptions);
+
+            var url = string.Format("{0}/{1}", Urls.Charges, chargeId);
+            url = this.ApplyAllParameters(updateOptions, url, false);
+
+            var response = Requestor.PostString(url, requestOptions);
+
+            return Mapper<StripeCharge>.MapFromJson(response);
+        }
+
         public virtual StripeCharge Get(string chargeId, StripeRequestOptions requestOptions = null)
         {
             requestOptions = SetupRequestOptions(requestOptions);

--- a/src/Stripe/Services/Charges/StripeChargeUpdateOptions.cs
+++ b/src/Stripe/Services/Charges/StripeChargeUpdateOptions.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using System;
+
+namespace Stripe
+{
+    public class StripeChargeUpdateOptions
+    {
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("receipt_email")]
+        public string ReceiptEmail { get; set; }
+
+        // shipping
+    }
+}

--- a/src/Stripe/Stripe.csproj
+++ b/src/Stripe/Stripe.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Constants\StripeRefundReasons.cs" />
     <Compile Include="Infrastructure\ExpandableProperty.cs" />
     <Compile Include="Services\Balance\StripeBalanceTransactionListOptions.cs" />
+    <Compile Include="Services\Charges\StripeChargeUpdateOptions.cs" />
     <Compile Include="Services\Coupons\StripeCouponUpdateOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundCreateOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundService.cs" />


### PR DESCRIPTION
The StripeChargeUpdateOptions takes 3 parameters, *description*, *metadata* and *receipt_email*. I left out the *shipping* property, as it is not included in the StripeChargeCreateOptions object.

I tried to include the *fraud_details* property as well, but it kept acting up when I tested it against the Stripe API, giving me an error message that read "Invalid hash". I have no idea what that means, so I just removed it altogether as I don't really need this parameter.