### PR TITLE
Update .NET version in Nuspec to lib\net46

### DIFF
--- a/Stripe.net.nuspec
+++ b/Stripe.net.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="working40\Stripe.net.dll" target="lib\net40" />
+    <file src="working40\Stripe.net.dll" target="lib\net46" />
   </files>
 </package>


### PR DESCRIPTION
Tried to install this package to a .NET 4.5 project. It caused a very confusing error, which I tracked down to the fact that the project could not be built using the referenced Stripe.net assembly. I believe this change is what is needed to let NuGet know that it can't install this version to  4.5 projects.