### PR TITLE
Fraud updates

### DIFF
--- a/src/Stripe/Entities/StripeCharge.cs
+++ b/src/Stripe/Entities/StripeCharge.cs
@@ -117,7 +117,9 @@ namespace Stripe
         public string ReceiptNumber { get; set; }
 
         // fraud details
-
+        [JsonProperty("fraud_details")]
+        public StripeFraudDetails FraudDetails { get; set; }
+        
         // shipping
 
         // application_fee

--- a/src/Stripe/Entities/StripeFraudDetails.cs
+++ b/src/Stripe/Entities/StripeFraudDetails.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeFraudDetails : StripeObject
+    {
+        [JsonProperty("stripe_report")]
+        public string StripeReport { get; set; }
+    }
+}

--- a/src/Stripe/Infrastructure/ParameterBuilder.cs
+++ b/src/Stripe/Infrastructure/ParameterBuilder.cs
@@ -36,6 +36,15 @@ namespace Stripe
                                 newUrl = ApplyParameterToUrl(newUrl, string.Format("metadata[{0}]", key), metadata[key]);
                             }
                         }
+                        else if (string.Compare(attribute.PropertyName, "fraud_details", true) == 0)
+                        {
+                            var fraudDetails = (Dictionary<string, string>)value;
+
+                            foreach (string key in fraudDetails.Keys)
+                            {
+                                newUrl = ApplyParameterToUrl(newUrl, string.Format("fraud_details[{0}]", key), fraudDetails[key]);
+                            }
+                        }
                         else if (property.PropertyType == typeof(StripeDateFilter))
                         {
                             var filter = (StripeDateFilter)value;

--- a/src/Stripe/Services/Charges/StripeChargeUpdateOptions.cs
+++ b/src/Stripe/Services/Charges/StripeChargeUpdateOptions.cs
@@ -14,5 +14,8 @@ namespace Stripe
 
         [JsonProperty("receipt_email")]
         public string ReceiptEmail { get; set; }
+        
+        [JsonProperty("fraud_details")]
+        public Dictionary<string, string> FraudDetails { get; set; }
     }
 }


### PR DESCRIPTION
The library was missing fraud checks, and with the amount of fraud happening right now, it's time to change that!

Therefore, I have added a simple StripeFraudDetails class and updated StripeChargeUpdateOptions to
allow user FraudDetails to be added. 

StripeCharge now returns StripeFraudDetails.