### PR TITLE
Create customer with plan - add support for "now" in trial end date

### DIFF
--- a/src/Stripe.Tests/Stripe.Tests.csproj
+++ b/src/Stripe.Tests/Stripe.Tests.csproj
@@ -56,6 +56,7 @@
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -75,6 +76,7 @@
     <Compile Include="balance\when_retrieving_a_balance.cs" />
     <Compile Include="charges\test_data\stripe_charge_update_options.cs" />
     <Compile Include="charges\when_updating_a_charge.cs" />
+    <Compile Include="customers\when_creating_a_customer_with_trial_end_now.cs" />
     <Compile Include="idempotency\when_creating_a_charge_with_a_card_and_idempotency_key.cs" />
     <Compile Include="charges\charge_behaviors.cs" />
     <Compile Include="charges\when_capturing_a_charge_with_a_card.cs" />

--- a/src/Stripe.Tests/customers/test_data/stripe_customer_create_options.cs
+++ b/src/Stripe.Tests/customers/test_data/stripe_customer_create_options.cs
@@ -5,7 +5,7 @@ namespace Stripe.Tests.test_data
 {
     public static class stripe_customer_create_options
     {
-        public static StripeCustomerCreateOptions ValidCard(string _planId = null, string _couponId = null, DateTime? _trialEnd = null)
+        public static StripeCustomerCreateOptions ValidCard(string _planId = null, string _couponId = null, DateTime? _trialEnd = null, bool _trialEndNow = false)
         {
             var cardOptions = new StripeSourceOptions()
             {
@@ -41,7 +41,9 @@ namespace Stripe.Tests.test_data
             if (_couponId != null)
                 stripeCustomerCreateOptions.CouponId = _couponId;
 
-            if (_trialEnd != null)
+            if (_trialEndNow)
+                stripeCustomerCreateOptions.EndTrialNow = true;
+            else if (_trialEnd != null)
                 stripeCustomerCreateOptions.TrialEnd = _trialEnd;
 
             return stripeCustomerCreateOptions;

--- a/src/Stripe.Tests/customers/when_creating_a_customer_with_trial_end_now.cs
+++ b/src/Stripe.Tests/customers/when_creating_a_customer_with_trial_end_now.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Machine.Specifications;
+using System.Linq;
+
+namespace Stripe.Tests
+{
+    public class when_creating_a_customer_with_trial_end_now
+    {
+        protected static StripeCustomerCreateOptions StripeCustomerCreateOptions;
+        protected static StripeCustomer StripeCustomer;
+        protected static StripePlan StripePlan;
+        protected static StripeCoupon StripeCoupon;
+        protected static StripeCard StripeCard;
+        protected static StripeSubscription StripeSubscription;
+
+        private static StripeCustomerService _stripeCustomerService;
+
+        Establish context = () =>
+        {
+            var _stripePlanService = new StripePlanService();
+            StripePlan = _stripePlanService.Create(test_data.stripe_plan_create_options.Valid());
+
+            var _stripeCouponService = new StripeCouponService();
+            StripeCoupon = _stripeCouponService.Create(test_data.stripe_coupon_create_options.Valid());
+
+            _stripeCustomerService = new StripeCustomerService();
+            StripeCustomerCreateOptions = test_data.stripe_customer_create_options.ValidCard(StripePlan.Id, StripeCoupon.Id, null, true);
+        };
+
+        Because of = () =>
+        {
+            StripeCustomer = _stripeCustomerService.Create(StripeCustomerCreateOptions);
+
+            StripeCard = StripeCustomer.SourceList.Data.First();
+
+            StripeSubscription = StripeCustomer.StripeSubscriptionList.Data.First();
+        };
+
+        Behaves_like<customer_behaviors> behaviors;
+
+        It should_return_now_for_internal_trialend = () =>
+            StripeCustomerCreateOptions.TrialEndInternal.ShouldEqual("now");
+
+        It should_have_expired_trial_start = () =>
+            StripeSubscription.TrialStart.ShouldBeNull();
+
+        It should_have_expired_trial_end = () =>
+            StripeSubscription.TrialEnd.ShouldBeNull();
+    }
+}

--- a/src/Stripe/Services/Customers/StripeCustomerCreateOptions.cs
+++ b/src/Stripe/Services/Customers/StripeCustomerCreateOptions.cs
@@ -34,16 +34,22 @@ namespace Stripe
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 
+
         public DateTime? TrialEnd { get; set; }
+        
+        public bool EndTrialNow { get; set; }
 
         [JsonProperty("trial_end")]
-        internal long? TrialEndInternal
+        internal string TrialEndInternal
         {
             get
             {
-                if (!TrialEnd.HasValue) return null;
-
-                return EpochTime.ConvertDateTimeToEpoch(TrialEnd.Value);
+                if (EndTrialNow)
+                    return "now";
+                else if (TrialEnd.HasValue)
+                    return EpochTime.ConvertDateTimeToEpoch(TrialEnd.Value).ToString();
+                else
+                    return null;
             }
         }
     }


### PR DESCRIPTION
Same problem as issue https://github.com/jaymedavis/stripe.net/issues/91
Like 'Thwaitesy' mentioned on 9 Oct 2015, creating a customer should also support the trial_end "now" value. This way we can create the customer with one request instead of two (one for the customer and one for the subscription).