### PR TITLE
Improvements for #342 To Add Dispute Structured Evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Stripe.userprefs
 
 # my secretz
 my_test_keys.txt
+
+src/Stripe.v12.suo
+src/Stripe.sln

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@ Stripe.userprefs
 
 # my secretz
 my_test_keys.txt
-
-src/Stripe.v12.suo
-src/Stripe.sln

--- a/src/Stripe.Portable/Stripe.Portable.csproj
+++ b/src/Stripe.Portable/Stripe.Portable.csproj
@@ -111,6 +111,12 @@
     <Compile Include="..\Stripe\Entities\StripeEventData.cs">
       <Link>Entities\StripeEventData.cs</Link>
     </Compile>
+    <Compile Include="..\Stripe\Entities\StripeEvidence.cs">
+      <Link>Entities\StripeEvidence.cs</Link>
+    </Compile>
+    <Compile Include="..\Stripe\Entities\StripeEvidenceDetails.cs">
+      <Link>Entities\StripeEvidenceDetails.cs</Link>
+    </Compile>
     <Compile Include="..\Stripe\Entities\StripeFee.cs">
       <Link>Entities\StripeFee.cs</Link>
     </Compile>
@@ -278,6 +284,12 @@
     </Compile>
     <Compile Include="..\Stripe\Services\Customers\StripeCustomerUpdateOptions.cs">
       <Link>Services\Customers\StripeCustomerUpdateOptions.cs</Link>
+    </Compile>
+    <Compile Include="..\Stripe\Services\Disputes\StripeDisputeListOptions.cs">
+      <Link>Services\Disputes\StripeDisputeListOptions.cs</Link>
+    </Compile>
+    <Compile Include="..\Stripe\Services\Disputes\StripeDisputeResponse.cs">
+      <Link>Services\Disputes\StripeDisputeResponse.cs</Link>
     </Compile>
     <Compile Include="..\Stripe\Services\Disputes\StripeDisputeService.cs">
       <Link>Services\Disputes\StripeDisputeService.cs</Link>

--- a/src/Stripe.Tests/Stripe.Tests.csproj
+++ b/src/Stripe.Tests/Stripe.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="balance\when_listing_balancetransactions.cs" />
     <Compile Include="balance\when_listing_balancetransactions_for_charge.cs" />
     <Compile Include="balance\when_retrieving_a_balance.cs" />
+    <Compile Include="files\when_uploading_a_file.cs" />
     <Compile Include="Setup.cs" />
     <Compile Include="charges\test_data\stripe_charge_update_options.cs" />
     <Compile Include="charges\when_updating_a_charge.cs" />

--- a/src/Stripe.Tests/files/when_uploading_a_file.cs
+++ b/src/Stripe.Tests/files/when_uploading_a_file.cs
@@ -1,0 +1,21 @@
+﻿using Machine.Specifications;
+
+namespace Stripe.Tests
+{
+    public class when_uploading_a_file
+    {
+        protected static StripeFileUpload StripeFile;
+
+        private static StripeFileService _stipeFileService;
+
+        Establish context = () =>
+        {
+            _stipeFileService = new StripeFileService();
+        };
+
+        //TODO:
+        //Because of = () =>
+        //    StripeFile = _stipeFileService.UploadDisputeEvidence(...);
+
+    }
+}

--- a/src/Stripe/Entities/StripeDispute.cs
+++ b/src/Stripe/Entities/StripeDispute.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Newtonsoft.Json;
 using Stripe.Infrastructure;
-using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 
 namespace Stripe
@@ -49,8 +48,11 @@ namespace Stripe
         [JsonProperty("balance_transactions")]
         public List<StripeBalanceTransaction> BalanceTransactions { get; set; }
 
-        // needs evidence object
-        // needs evidence_details
+        [JsonProperty("evidence")]
+        public StripeEvidence Evidence { get; set; }
+
+        [JsonProperty("evidence_details")]
+        public StripeEvidenceDetails EvidenceDetails { get; set; }
 
         [JsonProperty("is_charge_refundable")]
         public bool IsChargeRefundable { get; set; }

--- a/src/Stripe/Entities/StripeEvidence.cs
+++ b/src/Stripe/Entities/StripeEvidence.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeEvidence
+    {
+        [JsonProperty("access_activity_log")]
+        public string AccessActivityLog { get; set; }
+
+        [JsonProperty("billing_address")]
+        public string BillingAddress { get; set; }
+
+        [JsonProperty("cancellation_policy")]
+        public string CancellationPolicy { get; set; }
+
+        [JsonProperty("cancellation_policy_disclosure")]
+        public string CancellationPolicyDisclosure { get; set; }
+
+        [JsonProperty("cancellation_rebuttal")]
+        public string CancellationRebuttal { get; set; }
+
+        [JsonProperty("customer_communication")]
+        public string CustomerCommunication { get; set; }
+
+        [JsonProperty("customer_email_address")]
+        public string CustomerEmailAddress { get; set; }
+
+        [JsonProperty("customer_name")]
+        public string CustomerName { get; set; }
+
+        [JsonProperty("customer_purchase_ip")]
+        public string CustomerIpAddress { get; set; }
+
+        [JsonProperty("customer_signature")]
+        public string CustomerSignature { get; set; }
+
+        [JsonProperty("duplicate_charge_documentation")]
+        public string DuplicateChargeDocumentation { get; set; }
+
+        [JsonProperty("duplicate_charge_explanation")]
+        public string DuplicateChargeExplanation { get; set; }
+
+        [JsonProperty("duplicate_charge_id")]
+        public string DuplicateChargeId { get; set; }
+
+        [JsonProperty("product_description")]
+        public string ProductDescription { get; set; }
+
+        [JsonProperty("receipt")]
+        public string Receipt { get; set; }
+        
+        [JsonProperty("refund_policy")]
+        public string RefundPolicy { get; set; }
+
+        [JsonProperty("refund_policy_disclosure")]
+        public string RefundPolicyDisclosure { get; set; }
+
+        [JsonProperty("refund_refusal_explanation")]
+        public string RefundRefusalExplanation { get; set; }
+
+        [JsonProperty("service_date")]
+        public string ServiceDate { get; set; }
+
+        [JsonProperty("service_documentation")]
+        public string ServiceDocumentation { get; set; }
+
+        [JsonProperty("shipping_address")]
+        public string ShippingAddress { get; set; }
+
+        [JsonProperty("shipping_carrier")]
+        public string ShippingCarrier { get; set; }
+
+        [JsonProperty("shipping_date")]
+        public string ShippingDate { get; set; }
+
+        [JsonProperty("shipping_documentation")]
+        public string ShippingDocumentation { get; set; }
+        
+        [JsonProperty("shipping_tracking_number")]
+        public string ShippingTrackingNumber { get; set; }
+
+        [JsonProperty("uncategorized_file")]
+        public string UncategorizedFile { get; set; }
+
+        [JsonProperty("uncategorized_text")]
+        public string UncategorizedText { get; set; }
+    }
+}

--- a/src/Stripe/Entities/StripeEvidenceDetails.cs
+++ b/src/Stripe/Entities/StripeEvidenceDetails.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Newtonsoft.Json;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+    public class StripeEvidenceDetails
+    {
+        [JsonProperty("due_by")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime DueBy { get; set; }
+
+        [JsonProperty("has_evidence")]
+        public bool HasEvidence { get; set; }
+
+        [JsonProperty("past_due")]
+        public bool PastDue { get; set; }
+
+        [JsonProperty("submission_count")]
+        public int SubmissionCount { get; set; }
+
+    }
+}

--- a/src/Stripe/Infrastructure/ParameterBuilder.cs
+++ b/src/Stripe/Infrastructure/ParameterBuilder.cs
@@ -77,6 +77,10 @@ namespace Stripe
                             var stripeAccountBankAccountOptions = (StripeAccountBankAccountOptions)value;
                             newUrl = ApplyNestedObjectProperties(newUrl, stripeAccountBankAccountOptions);
                         }
+                        else if (obj.GetType() == typeof(StripeEvidence))
+                        {
+                            newUrl = ApplyParameterToUrl(newUrl, "evidence[" + attribute.PropertyName + "]", value.ToString());
+                        }
                         else
                         {
                             newUrl = ApplyParameterToUrl(newUrl, attribute.PropertyName, value.ToString());
@@ -135,5 +139,6 @@ namespace Stripe
 
             return newUrl;
         }
+        
     }
 }

--- a/src/Stripe/Infrastructure/Urls.cs
+++ b/src/Stripe/Infrastructure/Urls.cs
@@ -92,6 +92,16 @@
             get { return BaseUrl + "/application_fees"; }
         }
 
+        public static string Files
+        {
+            get { return FileBaseUrl + "/files"; }
+        }
+
+        private static string FileBaseUrl
+        {
+            get { return "https://uploads.stripe.com/v1"; }
+        }
+
         private static string BaseUrl
         {
             get { return "https://api.stripe.com/v1"; }

--- a/src/Stripe/Infrastructure/Urls.cs
+++ b/src/Stripe/Infrastructure/Urls.cs
@@ -2,6 +2,11 @@
 {
     internal static class Urls
     {
+        public static string Disputes
+        {
+            get { return BaseUrl + "/disputes"; }
+        }
+
         public static string Invoices
         {
             get { return BaseUrl + "/invoices"; }

--- a/src/Stripe/Services/Disputes/StripeDisputeListOptions.cs
+++ b/src/Stripe/Services/Disputes/StripeDisputeListOptions.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeDisputeListOptions : StripeListOptions
+    {
+        [JsonProperty("created")]
+        public StripeDateFilter Created { get; set; }
+    }
+}

--- a/src/Stripe/Services/Disputes/StripeDisputeResponse.cs
+++ b/src/Stripe/Services/Disputes/StripeDisputeResponse.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeDisputeResponse
+    {
+        [JsonProperty("product_description")]
+        public string ProductDescription { get; set; }
+
+        [JsonProperty("customer_name")]
+        public string CustomerName { get; set; }
+
+        [JsonProperty("customer_signature")]
+        public string CustomerSignature { get; set; }
+
+        [JsonProperty("customer_email_address")]
+        public string CustomerEmailAddress { get; set; }
+
+        [JsonProperty("customer_purchase_ip")]
+        public string CustomerIpAddress { get; set; }
+
+        [JsonProperty("billing_address")]
+        public string BillingAddress { get; set; }
+
+        /// <summary>
+        /// Details or File Upload Id
+        /// </summary>
+        [JsonProperty("receipt")]
+        public string Receipt { get; set; }
+
+        [JsonProperty("shipping_address")]
+        public string ShippingAddress { get; set; }
+
+        [JsonProperty("shipping_date")]
+        public DateTime ShippingDate { get; set; }
+
+        [JsonProperty("shipping_carrier")]
+        public string ShippingCarrier { get; set; }
+
+        [JsonProperty("shipping_tracking_number")]
+        public string ShippingTrackingNumber { get; set; }
+
+        [JsonProperty("shipping_documentation")]
+        public string ShippingDocumentation { get; set; }
+
+        [JsonProperty("access_activity_log")]
+        public string AccessActivityLog { get; set; }
+
+        [JsonProperty("service_date")]
+        public DateTime ServiceDate { get; set; }
+
+        [JsonProperty("service_documentation")]
+        public string ServiceDocumentation { get; set; }
+
+        [JsonProperty("duplicate_charge_id")]
+        public string DuplicateChargeId { get; set; }
+
+        [JsonProperty("duplicate_charge_explanation")]
+        public string DuplicateChargeExplanation { get; set; }
+
+        [JsonProperty("duplicate_charge_documentation")]
+        public string DuplicateChargeDocumentation { get; set; }
+
+        [JsonProperty("refund_policy")]
+        public string RefundPolicy { get; set; }
+
+        [JsonProperty("refund_policy_disclosure")]
+        public string RefundPolicyDisclosure { get; set; }
+
+        [JsonProperty("refund_refusal_explanation")]
+        public string RefundRefusalExplanation { get; set; }
+
+        [JsonProperty("cancellation_policy")]
+        public string CancellationPolicy { get; set; }
+
+        [JsonProperty("cancellation_policy_disclosure")]
+        public string CancellationPolicyDisclosure { get; set; }
+
+        [JsonProperty("cancellation_rebuttal")]
+        public string CancellationRebuttal { get; set; }
+
+        /// <summary>
+        /// Details or File Upload Id
+        /// </summary>
+        [JsonProperty("customer_communication")]
+        public string CustomerCommunication { get; set; }
+
+        [JsonProperty("uncategorized_text")]
+        public string UncategorizedText { get; set; }
+
+        /// <summary>
+        /// File Upload Id
+        /// </summary>
+        [JsonProperty("uncategorized_file")]
+        public string UncategorizedFile { get; set; }
+    }
+}

--- a/src/Stripe/Services/Disputes/StripeDisputeService.cs
+++ b/src/Stripe/Services/Disputes/StripeDisputeService.cs
@@ -1,4 +1,7 @@
-﻿namespace Stripe
+﻿
+using System.Collections.Generic;
+
+namespace Stripe
 {
     public class StripeDisputeService : StripeService
     {
@@ -20,6 +23,43 @@
             var response = Requestor.PostString(url, requestOptions);
 
             return Mapper<StripeDispute>.MapFromJson(response);
+        }
+
+        public virtual StripeDispute Get(string disputeId, StripeRequestOptions requestOptions = null)
+        {
+            requestOptions = SetupRequestOptions(requestOptions);
+
+            var url = string.Format("{0}/{1}", Urls.Disputes, disputeId);
+            url = this.ApplyAllParameters(null, url, false);
+
+            var response = Requestor.GetString(url, requestOptions);
+
+            return Mapper<StripeDispute>.MapFromJson(response);
+        }
+
+        public virtual StripeDispute Update(string disputeId, StripeEvidence evidence, StripeRequestOptions requestOptions = null)
+        {
+            requestOptions = SetupRequestOptions(requestOptions);
+
+            var url = string.Format("{0}/{1}", Urls.Disputes, disputeId);
+
+            url = this.ApplyAllParameters(evidence, url, false);
+            
+            var response = Requestor.PostString(url, requestOptions);
+
+            return Mapper<StripeDispute>.MapFromJson(response);
+        }
+
+        public virtual IEnumerable<StripeDispute> List(StripeDisputeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        {
+            requestOptions = SetupRequestOptions(requestOptions);
+
+            var url = Urls.Disputes;
+            url = this.ApplyAllParameters(listOptions, url, true);
+
+            var response = Requestor.GetString(url, requestOptions);
+
+            return Mapper<StripeDispute>.MapCollectionFromJson(response);
         }
     }
 }

--- a/src/Stripe/Services/File/StripeFileService.cs
+++ b/src/Stripe/Services/File/StripeFileService.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+
+namespace Stripe
+{
+    public class StripeFileService : StripeService
+    {
+        public StripeFileService(string apiKey = null) : base(apiKey)
+        {
+        }
+
+        public StripeFileUpload UploadDisputeEvidence(string fileName, Stream stream, StripeRequestOptions requestOptions = null)
+        {
+            requestOptions = SetupRequestOptions(requestOptions);
+            
+            var response = Requestor.PostMultiPartFile(Urls.Files, fileName, stream, "dispute_evidence", requestOptions);
+            
+            return Mapper<StripeFileUpload>.MapFromJson(response);
+        }
+
+    }
+}

--- a/src/Stripe/Stripe.csproj
+++ b/src/Stripe/Stripe.csproj
@@ -61,6 +61,8 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Entities\StripeEvidence.cs" />
+    <Compile Include="Entities\StripeEvidenceDetails.cs" />
     <Compile Include="Entities\StripeManagedAccountKeys.cs" />
     <Compile Include="Entities\StripeBirthDay.cs" />
     <Compile Include="Entities\StripeAddress.cs" />
@@ -91,6 +93,8 @@
     <Compile Include="Services\Balance\StripeBalanceTransactionListOptions.cs" />
     <Compile Include="Services\Charges\StripeChargeUpdateOptions.cs" />
     <Compile Include="Services\Coupons\StripeCouponUpdateOptions.cs" />
+    <Compile Include="Services\Disputes\StripeDisputeListOptions.cs" />
+    <Compile Include="Services\Disputes\StripeDisputeResponse.cs" />
     <Compile Include="Services\File\StripeFileService.cs" />
     <Compile Include="Services\Invoices\StripeUpcomingInvoiceOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundCreateOptions.cs" />

--- a/src/Stripe/Stripe.csproj
+++ b/src/Stripe/Stripe.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Services\Balance\StripeBalanceTransactionListOptions.cs" />
     <Compile Include="Services\Charges\StripeChargeUpdateOptions.cs" />
     <Compile Include="Services\Coupons\StripeCouponUpdateOptions.cs" />
+    <Compile Include="Services\File\StripeFileService.cs" />
     <Compile Include="Services\Invoices\StripeUpcomingInvoiceOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundCreateOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundService.cs" />


### PR DESCRIPTION
This change extends the StripeDisputeService by adding an Update() method that allows one to submit evidence to a dispute given a dispute id, it also adds a List() method which allows for the enumeration of dispute objects. This change also allows for uploading of File based evidence.