### PR TITLE
Support for pay_immediately during customer create

### DIFF
--- a/src/Stripe.Tests/Stripe.Tests.csproj
+++ b/src/Stripe.Tests/Stripe.Tests.csproj
@@ -86,6 +86,8 @@
     <Compile Include="bank_accounts\when_creating_a_bank_account.cs" />
     <Compile Include="card\when_creating_a_card.cs" />
     <Compile Include="charges\when_refunding_and_setting_fraud_details.cs" />
+    <Compile Include="customers\when_creating_a_customer_with_pay_immediately_false.cs" />
+    <Compile Include="customers\when_creating_a_customer_with_pay_immediately_true.cs" />
     <Compile Include="Setup.cs" />
     <Compile Include="charges\test_data\stripe_charge_update_options.cs" />
     <Compile Include="charges\when_updating_a_charge.cs" />

--- a/src/Stripe.Tests/customers/test_data/stripe_customer_create_options.cs
+++ b/src/Stripe.Tests/customers/test_data/stripe_customer_create_options.cs
@@ -5,7 +5,7 @@ namespace Stripe.Tests.test_data
 {
     public static class stripe_customer_create_options
     {
-        public static StripeCustomerCreateOptions ValidCard(string _planId = null, string _couponId = null, DateTime? _trialEnd = null, bool _trialEndNow = false)
+        public static StripeCustomerCreateOptions ValidCard(string _planId = null, string _couponId = null, DateTime? _trialEnd = null, bool _trialEndNow = false, bool? _payImmediately = null)
         {
             // obsolete: var cardOptions = new StripeSourceOptions()
             var cardOptions = new SourceCard()
@@ -33,7 +33,8 @@ namespace Stripe.Tests.test_data
                 {
                     { "A", "Value-A" },
                     { "B", "Value-B" }
-                }
+                },
+                PayImmediately = _payImmediately
             };
 
             if (_planId != null)

--- a/src/Stripe.Tests/customers/when_creating_a_customer.cs
+++ b/src/Stripe.Tests/customers/when_creating_a_customer.cs
@@ -47,7 +47,7 @@ namespace Stripe.Tests
         It should_have_the_correct_metadata = () =>
             StripeCustomer.Metadata.ShouldContainOnly(StripeCustomerCreateOptions.Metadata);
 
-        It should_have_an_unpaid_invoice = () =>
+        It should_have_a_paid_invoice = () =>
             StripeInvoices.First().Paid.ShouldBeTrue();
     }
 }

--- a/src/Stripe.Tests/customers/when_creating_a_customer_with_pay_immediately_false.cs
+++ b/src/Stripe.Tests/customers/when_creating_a_customer_with_pay_immediately_false.cs
@@ -2,9 +2,9 @@
 using Machine.Specifications;
 using System.Linq;
 
-namespace Stripe.Tests
+namespace Stripe.Tests.customers
 {
-    public class when_creating_a_customer
+    class when_creating_a_customer_with_pay_immediately_false
     {
         protected static StripeCustomerCreateOptions StripeCustomerCreateOptions;
         protected static StripeCustomer StripeCustomer;
@@ -13,6 +13,7 @@ namespace Stripe.Tests
         protected static StripeCard StripeCard;
         protected static StripeInvoice[] StripeInvoices;
 
+        private static StripeSubscription _stripeSubscription;
         private static StripeCustomerService _stripeCustomerService;
         private static StripeInvoiceService _stripeInvoiceService;
 
@@ -25,7 +26,7 @@ namespace Stripe.Tests
             StripeCoupon = _stripeCouponService.Create(test_data.stripe_coupon_create_options.Valid());
 
             _stripeCustomerService = new StripeCustomerService();
-            StripeCustomerCreateOptions = test_data.stripe_customer_create_options.ValidCard(StripePlan.Id, StripeCoupon.Id, DateTime.UtcNow.AddDays(5));
+            StripeCustomerCreateOptions = test_data.stripe_customer_create_options.ValidCard(StripePlan.Id, StripeCoupon.Id, DateTime.UtcNow.AddDays(5), _payImmediately: false);
 
             _stripeInvoiceService = new StripeInvoiceService();
         };
@@ -36,18 +37,14 @@ namespace Stripe.Tests
 
             StripeCard = StripeCustomer.SourceList.Data.First();
 
+            _stripeSubscription = StripeCustomer.StripeSubscriptionList.Data.First();
+
             StripeInvoices = _stripeInvoiceService.List(new StripeInvoiceListOptions() { CustomerId = StripeCustomer.Id }).ToArray();
         };
 
         Behaves_like<customer_behaviors> behaviors;
 
-        It should_have_metadata = () =>
-            StripeCustomer.Metadata.Count.ShouldBeGreaterThan(0);
-
-        It should_have_the_correct_metadata = () =>
-            StripeCustomer.Metadata.ShouldContainOnly(StripeCustomerCreateOptions.Metadata);
-
         It should_have_an_unpaid_invoice = () =>
-            StripeInvoices.First().Paid.ShouldBeTrue();
+            StripeInvoices.First().Paid.ShouldBeFalse();
     }
 }

--- a/src/Stripe.Tests/customers/when_creating_a_customer_with_pay_immediately_true.cs
+++ b/src/Stripe.Tests/customers/when_creating_a_customer_with_pay_immediately_true.cs
@@ -2,9 +2,9 @@
 using Machine.Specifications;
 using System.Linq;
 
-namespace Stripe.Tests
+namespace Stripe.Tests.customers
 {
-    public class when_creating_a_customer
+    class when_creating_a_customer_with_pay_immediately_true
     {
         protected static StripeCustomerCreateOptions StripeCustomerCreateOptions;
         protected static StripeCustomer StripeCustomer;
@@ -13,6 +13,7 @@ namespace Stripe.Tests
         protected static StripeCard StripeCard;
         protected static StripeInvoice[] StripeInvoices;
 
+        private static StripeSubscription _stripeSubscription;
         private static StripeCustomerService _stripeCustomerService;
         private static StripeInvoiceService _stripeInvoiceService;
 
@@ -25,7 +26,7 @@ namespace Stripe.Tests
             StripeCoupon = _stripeCouponService.Create(test_data.stripe_coupon_create_options.Valid());
 
             _stripeCustomerService = new StripeCustomerService();
-            StripeCustomerCreateOptions = test_data.stripe_customer_create_options.ValidCard(StripePlan.Id, StripeCoupon.Id, DateTime.UtcNow.AddDays(5));
+            StripeCustomerCreateOptions = test_data.stripe_customer_create_options.ValidCard(StripePlan.Id, StripeCoupon.Id, DateTime.UtcNow.AddDays(5), _payImmediately: true);
 
             _stripeInvoiceService = new StripeInvoiceService();
         };
@@ -36,16 +37,12 @@ namespace Stripe.Tests
 
             StripeCard = StripeCustomer.SourceList.Data.First();
 
+            _stripeSubscription = StripeCustomer.StripeSubscriptionList.Data.First();
+
             StripeInvoices = _stripeInvoiceService.List(new StripeInvoiceListOptions() { CustomerId = StripeCustomer.Id }).ToArray();
         };
 
         Behaves_like<customer_behaviors> behaviors;
-
-        It should_have_metadata = () =>
-            StripeCustomer.Metadata.Count.ShouldBeGreaterThan(0);
-
-        It should_have_the_correct_metadata = () =>
-            StripeCustomer.Metadata.ShouldContainOnly(StripeCustomerCreateOptions.Metadata);
 
         It should_have_an_unpaid_invoice = () =>
             StripeInvoices.First().Paid.ShouldBeTrue();

--- a/src/Stripe.Tests/customers/when_creating_a_customer_with_pay_immediately_true.cs
+++ b/src/Stripe.Tests/customers/when_creating_a_customer_with_pay_immediately_true.cs
@@ -44,7 +44,7 @@ namespace Stripe.Tests.customers
 
         Behaves_like<customer_behaviors> behaviors;
 
-        It should_have_an_unpaid_invoice = () =>
+        It should_have_a_paid_invoice = () =>
             StripeInvoices.First().Paid.ShouldBeTrue();
     }
 }

--- a/src/Stripe/Services/Customers/StripeCustomerCreateOptions.cs
+++ b/src/Stripe/Services/Customers/StripeCustomerCreateOptions.cs
@@ -40,6 +40,9 @@ namespace Stripe
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 
+        [JsonProperty("pay_immediately")]
+        public bool? PayImmediately { get; set; }
+
         #region Trial End
 
         public DateTime? TrialEnd { get; set; }


### PR DESCRIPTION
Mail correspondence:

A PR or an issue would be great. This is a good question. Typically when things aren't documented, Stripe's stance is 'it's not guaranteed', which is why I avoid it. If you add this email verbatim as a GitHub PR, that will allow me to show them exactly what you are proposing and I can discuss it with them. :)

Jayme

On May 17, 2016, at 3:21 PM, Jens Rasmussen <jlr@cvation.com> wrote:
Hi Jayme
 
I was not sure whether to create an Issue or not (more like a change request).
 
To integrate Stripe with Avalara (handling of taxes – see https://www.avalara.com), Avalara needs to update Stripe invoices before they are paid. This is not immediately possible when creating a Stripe customer with a plan, since Stripe will try to have the first invoice paid as part of the verification process.
 
Stripe does support the scenario if one adds a pay_immediately=false flag to the customer create request (see e.g. https://help.avalara.com/kb/001/Why_are_my_subscription_invoices_in_Stripe_not_calculating_tax_or_posting_to_the_admin_console%3F).
Unfortunately it is not documented by Stripe, so I am not surprised that String.net does not support setting the flag.
 
I have forked Stripe.net and added a bool? PayImmediately property in the StripeCustomerCreateOptions class.
 
If you are interested, I can make a Pull request?
 
Best Regards
Jens