### PR TITLE
Update subscriptions to not need customerId

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -365,28 +365,28 @@ Subscriptions
 
 ```csharp
 	var subscriptionService = new StripeSubscriptionService();
-	StripeSubscription stripeSubscription = subscriptionService.Create(*customerId*, *planId*); // optional StripeSubscriptionCreateOptions
+	StripeSubscription stripeSubscription = subscriptionService.Create(StripeSubscriptionCreateOptions);
 ```
 
 ### Updating a subscription
 
 ```csharp
 	var subscriptionService = new StripeSubscriptionService();
-	StripeSubscription stripeSubscription = subscriptionService.Update(*customerId*, *subscriptionId*); // optional StripeSubscriptionUpdateOptions
+	StripeSubscription stripeSubscription = subscriptionService.Update(*subscriptionId*, StripeSubscriptionUpdateOptions);
 ```
 
 ### Retrieving a subscription
 
 ```csharp
 	var subscriptionService = new StripeSubscriptionService();
-	StripeSubscription stripeSubscription = subscriptionService.Get(*customerId*, *subscriptionId*);
+	StripeSubscription stripeSubscription = subscriptionService.Get(*subscriptionId*);
 ```
 
 ### Canceling a subscription
 
 ```csharp
 	var subscriptionService = new StripeSubscriptionService();
-	subscriptionService.Cancel(*customerId*, *subscriptionId*); // optional cancelAtPeriodEnd flag
+	subscriptionService.Cancel(*subscriptionId*); // optional cancelAtPeriodEnd flag
 ```
 
 ### List all subscriptions for a customer
@@ -394,6 +394,13 @@ Subscriptions
 ```csharp
 	var subscriptionService = new StripeSubscriptionService();
 	IEnumerable<StripeSubscription> response = subscriptionService.List(*customerId*); // optional StripeListOptions
+```
+
+### List all subscriptions
+
+```csharp
+	var subscriptionService = new StripeSubscriptionService();
+	IEnumerable<StripeSubscription> response = subscriptionService.List(); // optional StripeListOptions
 ```
 
 [StripeListOptions](#stripelistoptions-paging) for paging

--- a/src/Stripe.Tests/Stripe.Tests.csproj
+++ b/src/Stripe.Tests/Stripe.Tests.csproj
@@ -155,6 +155,7 @@
     <Compile Include="subscriptions\when_creating_a_subscription.cs" />
     <Compile Include="subscriptions\when_canceling_a_subscription_and_trying_to_retrieve.cs" />
     <Compile Include="subscriptions\when_updating_a_subscription_with_proration.cs" />
+    <Compile Include="subscriptions\when_listing_customer_subscriptions.cs" />
     <Compile Include="subscriptions\when_updating_a_subscription.cs" />
     <Compile Include="subscriptions\when_getting_a_subscription.cs" />
     <Compile Include="subscriptions\when_canceling_a_subscription.cs" />

--- a/src/Stripe.Tests/subscriptions/when_canceling_a_subscription.cs
+++ b/src/Stripe.Tests/subscriptions/when_canceling_a_subscription.cs
@@ -26,7 +26,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Cancel(_stripeCustomer.Id, _stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id);
+            _stripeSubscription = _stripeSubscriptionService.Cancel(_stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id);
 
         It should_be_a_canceled_subscription = () =>
             _stripeSubscription.Status.ShouldEqual("canceled");

--- a/src/Stripe.Tests/subscriptions/when_changing_a_subscription_plan.cs
+++ b/src/Stripe.Tests/subscriptions/when_changing_a_subscription_plan.cs
@@ -32,7 +32,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Update(_stripeCustomer.Id, _stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
+            _stripeSubscription = _stripeSubscriptionService.Update(_stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
 
         It should_have_the_same_id_as_the_new_plan = () =>
             _stripeSubscription.StripePlan.Id.ShouldEqual(_stripePlan2.Id);

--- a/src/Stripe.Tests/subscriptions/when_creating_a_subscription.cs
+++ b/src/Stripe.Tests/subscriptions/when_creating_a_subscription.cs
@@ -5,7 +5,6 @@ namespace Stripe.Tests
 {
     public class when_creating_a_subscription
     {
-        private static StripeCustomer _stripeCustomer;
         private static StripePlan _stripePlan;
         private static StripeSubscription _stripeSubscription;
         private static StripeSubscriptionService _stripeSubscriptionService;
@@ -14,7 +13,7 @@ namespace Stripe.Tests
         Establish context = () =>
         {
             var _stripeCustomerService = new StripeCustomerService();
-            _stripeCustomer = _stripeCustomerService.Create(test_data.stripe_customer_create_options.ValidCard());
+            var _stripeCustomer = _stripeCustomerService.Create(test_data.stripe_customer_create_options.ValidCard());
         
             var _stripePlanService = new StripePlanService();
             _stripePlan = _stripePlanService.Create(test_data.stripe_plan_create_options.Valid());
@@ -23,10 +22,12 @@ namespace Stripe.Tests
 
             _stripeSubscriptionCreateOptions = new StripeSubscriptionCreateOptions();
             _stripeSubscriptionCreateOptions.Quantity = 2;
+            _stripeSubscriptionCreateOptions.CustomerId = _stripeCustomer.Id;
+            _stripeSubscriptionCreateOptions.PlanId = _stripePlan.Id;
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Create(_stripeCustomer.Id, _stripePlan.Id, _stripeSubscriptionCreateOptions);
+            _stripeSubscription = _stripeSubscriptionService.Create(_stripeSubscriptionCreateOptions);
 
         It should_get_the_same_subscription = () =>
             _stripeSubscription.StripePlan.Id.ShouldEqual(_stripePlan.Id);

--- a/src/Stripe.Tests/subscriptions/when_getting_a_subscription.cs
+++ b/src/Stripe.Tests/subscriptions/when_getting_a_subscription.cs
@@ -26,7 +26,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Get(_stripeCustomer.Id, _stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id);
+            _stripeSubscription = _stripeSubscriptionService.Get(_stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id);
 
         It should_get_the_same_subscription = () =>
             _stripeSubscription.ShouldNotBeNull();

--- a/src/Stripe.Tests/subscriptions/when_listing_customer_subscriptions.cs
+++ b/src/Stripe.Tests/subscriptions/when_listing_customer_subscriptions.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using Machine.Specifications;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace Stripe.Tests
 {
-    public class when_canceling_a_subscription_and_trying_to_retrieve
+    public class when_listing_customer_subscriptions
     {
         private static StripeCustomer _stripeCustomer;
-        private static StripeSubscription _stripeSubscription;
+        private static List<StripeSubscription> _stripeSubscriptionList;
         private static StripeSubscriptionService _stripeSubscriptionService;
 
         Establish context = () =>
@@ -20,17 +21,14 @@ namespace Stripe.Tests
 
             var _stripeCustomerService = new StripeCustomerService();
             _stripeCustomer = _stripeCustomerService.Create(test_data.stripe_customer_create_options.ValidCard(_stripePlan.Id, _stripeCoupon.Id, DateTime.UtcNow.AddDays(10)));
-
+        
             _stripeSubscriptionService = new StripeSubscriptionService();
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Cancel(_stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, false);
+            _stripeSubscriptionList = _stripeSubscriptionService.List(_stripeCustomer.Id).ToList();
 
-        It should_throw_exception_when_retrieved = () =>
-        {
-            var exception = Catch.Exception(() => _stripeSubscriptionService.Get(_stripeSubscription.Id));
-            exception.Message.ShouldNotBeNull(); 
-        };
+        It should_have_one_subscription = () =>
+            _stripeSubscriptionList.Count().ShouldEqual(1);
     }
 }

--- a/src/Stripe.Tests/subscriptions/when_listing_subscriptions.cs
+++ b/src/Stripe.Tests/subscriptions/when_listing_subscriptions.cs
@@ -26,9 +26,9 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscriptionList = _stripeSubscriptionService.List(_stripeCustomer.Id).ToList();
+            _stripeSubscriptionList = _stripeSubscriptionService.List().ToList();
 
         It should_have_one_subscription = () =>
-            _stripeSubscriptionList.Count().ShouldEqual(1);
+            _stripeSubscriptionList.Count().ShouldBeGreaterThanOrEqualTo(1);
     }
 }

--- a/src/Stripe.Tests/subscriptions/when_updating_a_subscription.cs
+++ b/src/Stripe.Tests/subscriptions/when_updating_a_subscription.cs
@@ -29,7 +29,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Update(_stripeCustomer.Id, _stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
+            _stripeSubscription = _stripeSubscriptionService.Update(_stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
 
         It should_have_the_new_quantity = () =>
             _stripeSubscription.Quantity.ShouldEqual(5);

--- a/src/Stripe.Tests/subscriptions/when_updating_trial_end_date_subscription.cs
+++ b/src/Stripe.Tests/subscriptions/when_updating_trial_end_date_subscription.cs
@@ -32,7 +32,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Update(_stripeCustomer.Id, _stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
+            _stripeSubscription = _stripeSubscriptionService.Update(_stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
 
         It should_return_text_version_of_date_for_internal_trialend = () =>
             _stripeSubscriptionUpdateOptions.TrialEndInternal.ShouldEqual(EpochTime.ConvertDateTimeToEpoch(_stripeSubscriptionUpdateOptions.TrialEnd.Value).ToString());

--- a/src/Stripe.Tests/subscriptions/when_updating_trial_end_of_subscription.cs
+++ b/src/Stripe.Tests/subscriptions/when_updating_trial_end_of_subscription.cs
@@ -31,7 +31,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Update(_stripeCustomer.Id, _stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
+            _stripeSubscription = _stripeSubscriptionService.Update(_stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
 
         It should_return_now_for_internal_trialend = () =>
             _stripeSubscriptionUpdateOptions.TrialEndInternal.ShouldEqual("now");

--- a/src/Stripe/Infrastructure/Urls.cs
+++ b/src/Stripe/Infrastructure/Urls.cs
@@ -30,7 +30,7 @@
 
         public static string Recipients => BaseUrl + "/recipients";
 
-        public static string Subscriptions => BaseUrl + "/customers/{0}/subscriptions";
+        public static string Subscriptions => BaseUrl + "/subscriptions";
 
         public static string Transfers => BaseUrl + "/transfers";
 

--- a/src/Stripe/Services/Subscriptions/StripeSubscriptionService.cs
+++ b/src/Stripe/Services/Subscriptions/StripeSubscriptionService.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -10,9 +11,15 @@ namespace Stripe
 
         public bool ExpandCustomer { get; set; }
 
+        [Obsolete("Get with customerId is deprecated, use Get without the customerId.")]
         public virtual StripeSubscription Get(string customerId, string subscriptionId, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions + "/{1}", customerId, subscriptionId);
+            return Get(subscriptionId, requestOptions);
+        }
+
+        public virtual StripeSubscription Get(string subscriptionId, StripeRequestOptions requestOptions = null)
+        {
+            var url = string.Format(Urls.Subscriptions + "/{0}", subscriptionId);
 
             return Mapper<StripeSubscription>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(null, url, false),
@@ -20,20 +27,37 @@ namespace Stripe
             );
         }
 
+        [Obsolete("Create with customerId and planId is deprecated, use Create without the customerId planId by supplying those values in the StripeSubscriptionCreateOptions.")]
         public virtual StripeSubscription Create(string customerId, string planId, StripeSubscriptionCreateOptions createOptions = null, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions, customerId);
-            url = this.ApplyAllParameters(createOptions, url, false);
+            if (createOptions == null)
+              createOptions = new StripeSubscriptionCreateOptions();
+
+            createOptions.CustomerId = customerId;
+            createOptions.PlanId = planId;
+
+            return Create(createOptions, requestOptions);
+        }
+
+        public virtual StripeSubscription Create(StripeSubscriptionCreateOptions createOptions, StripeRequestOptions requestOptions = null)
+        {
+            var url = this.ApplyAllParameters(createOptions, Urls.Subscriptions, false);
 
             return Mapper<StripeSubscription>.MapFromJson(
-                Requestor.PostString(ParameterBuilder.ApplyParameterToUrl(url, "plan", planId),
+                Requestor.PostString(url,
                 SetupRequestOptions(requestOptions))
             );
         }
 
+        [Obsolete("Update with customerId is deprecated, use Update without the customerId.")]
         public virtual StripeSubscription Update(string customerId, string subscriptionId, StripeSubscriptionUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions + "/{1}", customerId, subscriptionId);
+            return Update(subscriptionId, updateOptions, requestOptions);
+        }
+
+        public virtual StripeSubscription Update(string subscriptionId, StripeSubscriptionUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
+        {
+            var url = string.Format(Urls.Subscriptions + "/{0}", subscriptionId);
 
             return Mapper<StripeSubscription>.MapFromJson(
                 Requestor.PostString(this.ApplyAllParameters(updateOptions, url, false),
@@ -41,9 +65,15 @@ namespace Stripe
             );
         }
 
+        [Obsolete("Cancel with customerId is deprecated, use Cancel without the customerId.")]
         public virtual StripeSubscription Cancel(string customerId, string subscriptionId, bool cancelAtPeriodEnd = false, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions + "/{1}", customerId, subscriptionId);
+            return Cancel(subscriptionId, cancelAtPeriodEnd, requestOptions);
+        }
+
+        public virtual StripeSubscription Cancel(string subscriptionId, bool cancelAtPeriodEnd = false, StripeRequestOptions requestOptions = null)
+        {
+            var url = string.Format(Urls.Subscriptions + "/{0}", subscriptionId);
             url = ParameterBuilder.ApplyParameterToUrl(url, "at_period_end", cancelAtPeriodEnd.ToString());
 
             return Mapper<StripeSubscription>.MapFromJson(
@@ -54,7 +84,7 @@ namespace Stripe
 
         public virtual IEnumerable<StripeSubscription> List(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions, customerId);
+            var url = string.Format("/customers/{0}" + Urls.Subscriptions, customerId);
 
             return Mapper<StripeSubscription>.MapCollectionFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, url, true),
@@ -62,9 +92,23 @@ namespace Stripe
             );
         }
 
+        public virtual IEnumerable<StripeSubscription> List(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        {
+            return Mapper<StripeSubscription>.MapCollectionFromJson(
+                Requestor.GetString(this.ApplyAllParameters(listOptions, Urls.Subscriptions, true),
+                SetupRequestOptions(requestOptions))
+            );
+        }
+
+        [Obsolete("GetAsync with customerId is deprecated, use GetAync without the customerId.")]
         public virtual async Task<StripeSubscription> GetAsync(string customerId, string subscriptionId, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions + "/{1}", customerId, subscriptionId);
+            return await GetAsync(subscriptionId, requestOptions);
+        }
+
+        public virtual async Task<StripeSubscription> GetAsync(string subscriptionId, StripeRequestOptions requestOptions = null)
+        {
+            var url = string.Format(Urls.Subscriptions + "/{0}", subscriptionId);
 
             return Mapper<StripeSubscription>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(null, url, false),
@@ -72,20 +116,37 @@ namespace Stripe
             );
         }
 
+        [Obsolete("CreateAsync with customerId and planId is deprecated, use CreateAsync without the customerId planId by supplying those values in the StripeSubscriptionCreateOptions.")]
         public virtual async Task<StripeSubscription> CreateAsync(string customerId, string planId, StripeSubscriptionCreateOptions createOptions = null, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions, customerId);
-            url = this.ApplyAllParameters(createOptions, url, false);
+            if (createOptions == null)
+              createOptions = new StripeSubscriptionCreateOptions();
+
+            createOptions.CustomerId = customerId;
+            createOptions.PlanId = planId;
+
+            return await CreateAsync(createOptions, requestOptions);
+        }
+
+        public virtual async Task<StripeSubscription> CreateAsync(StripeSubscriptionCreateOptions createOptions = null, StripeRequestOptions requestOptions = null)
+        {
+            var url = this.ApplyAllParameters(createOptions, Urls.Subscriptions, false);
 
             return Mapper<StripeSubscription>.MapFromJson(
-                await Requestor.PostStringAsync(ParameterBuilder.ApplyParameterToUrl(url, "plan", planId),
+                await Requestor.PostStringAsync(url,
                 SetupRequestOptions(requestOptions))
             );
         }
 
+        [Obsolete("UpdateAsync with customerId is deprecated, use UpdateAsync without the customerId.")]
         public virtual async Task<StripeSubscription> UpdateAsync(string customerId, string subscriptionId, StripeSubscriptionUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions + "/{1}", customerId, subscriptionId);
+            return await UpdateAsync(subscriptionId, updateOptions, requestOptions);
+        }
+
+        public virtual async Task<StripeSubscription> UpdateAsync(string subscriptionId, StripeSubscriptionUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
+        {
+            var url = string.Format(Urls.Subscriptions + "/{0}", subscriptionId);
 
             return Mapper<StripeSubscription>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, url, false),
@@ -93,9 +154,15 @@ namespace Stripe
             );
         }
 
+        [Obsolete("CancelAsync with customerId is deprecated, use CancelAsync without the customerId.")]
         public virtual async Task<StripeSubscription> CancelAsync(string customerId, string subscriptionId, bool cancelAtPeriodEnd = false, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions + "/{1}", customerId, subscriptionId);
+            return await CancelAsync(subscriptionId, cancelAtPeriodEnd, requestOptions);
+        }
+
+        public virtual async Task<StripeSubscription> CancelAsync(string subscriptionId, bool cancelAtPeriodEnd = false, StripeRequestOptions requestOptions = null)
+        {
+            var url = string.Format(Urls.Subscriptions + "/{0}", subscriptionId);
             url = ParameterBuilder.ApplyParameterToUrl(url, "at_period_end", cancelAtPeriodEnd.ToString());
 
             return Mapper<StripeSubscription>.MapFromJson(
@@ -106,12 +173,20 @@ namespace Stripe
 
         public virtual async Task<IEnumerable<StripeSubscription>> ListAsync(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions, customerId);
+            var url = string.Format("/customers/{0}" + Urls.Subscriptions, customerId);
 
             return Mapper<StripeSubscription>.MapCollectionFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, url, true),
                 SetupRequestOptions(requestOptions))
             );
         }
-   }
+
+        public virtual async Task<IEnumerable<StripeSubscription>> ListAsync(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        {
+            return Mapper<StripeSubscription>.MapCollectionFromJson(
+                await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Subscriptions, true),
+                SetupRequestOptions(requestOptions))
+            );
+        }
+    }
 }

--- a/src/Stripe/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -20,6 +20,9 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+
         [JsonProperty("plan")]
         public string PlanId { get; set; }
 


### PR DESCRIPTION
Resolves #514
Use stripe subscriptions endpoints directly (no customer)
Deprecate subscription methods using customerId
Add method to list all subscriptions
Update readme to reflect signature changes

Disclaimer: I am not a .NET developer... but these changes seemed simple enough to do. I may be wrong; review the changes carefully.