### PR TITLE
Overriding the endpoints and the security protocols

### DIFF
--- a/src/Stripe/Infrastructure/Requestor.cs
+++ b/src/Stripe/Infrastructure/Requestor.cs
@@ -7,10 +7,22 @@ using System.Threading.Tasks;
 
 namespace Stripe
 {
-    internal static class Requestor
+    public static class Requestor
     {
         internal static HttpClient HttpClient { get; private set; }
         internal static string Version { get; }
+
+#if !PORTABLE
+
+        /// <summary>
+        /// Gets or sets the type of the security protocol.
+        /// </summary>
+        /// <value>
+        /// The type of the security protocol.
+        /// </value>
+        public static SecurityProtocolType SecurityProtocol { get; set; } = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+
+#endif
 
         static Requestor()
         {
@@ -81,7 +93,7 @@ namespace Stripe
             requestOptions.ApiKey = requestOptions.ApiKey ?? StripeConfiguration.GetApiKey();
 
 #if !PORTABLE
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+            ServicePointManager.SecurityProtocol = SecurityProtocol;
 #endif
 
             var request = BuildRequest(method, url);

--- a/src/Stripe/Infrastructure/Urls.cs
+++ b/src/Stripe/Infrastructure/Urls.cs
@@ -1,6 +1,6 @@
 ﻿namespace Stripe
 {
-    internal static class Urls
+    public static class Urls
     {
         public static string Invoices => BaseUrl + "/invoices";
 
@@ -36,12 +36,12 @@
 
         public static string ApplicationFees => BaseUrl + "/application_fees";
 
-        internal static string BaseUrl => "https://api.stripe.com/v1";
+        public static string BaseUrl { get; set; } = "https://api.stripe.com/v1";
 
         public static string OAuthToken => BaseConnectUrl + "/oauth/token";
 
         public static string OAuthDeauthorize => BaseConnectUrl + "/oauth/deauthorize";
 
-        private static string BaseConnectUrl => "https://connect.stripe.com";
+        public static string BaseConnectUrl { get; set; } = "https://connect.stripe.com";
     }
 }


### PR DESCRIPTION
Hi, as mentioned in https://github.com/jaymedavis/stripe.net/issues/500#issuecomment-219142516 I added some minor fixes to allow for using different endpoints instead of the original Stripe ones, as well as changing the supported security protocols, e.g. disabling TLSv1.2.

We are running our applications using the `dotnet` CLI (preview1) tooling on mono. Sadly, mono does not support TLS 1.2 at all, so we are using a simple nginx forward proxy as a middle man that does speak plain HTTP on the inside and wraps the actual request to Stripe in TLS. In order to achieve that, we have to point all Stripe related requests to that proxy and also - optionally - turn off TLS 1.2. The last step might be optional.

This is the same with the PayPal API by the way, for which the SDK already supports setting of arbitrary endpoints via a configuration dictionary.