### PR TITLE
Support for paginated queries of pending invoice line items

### DIFF
--- a/src/Stripe.Portable/Stripe.Portable.csproj
+++ b/src/Stripe.Portable/Stripe.Portable.csproj
@@ -342,6 +342,9 @@
     <Compile Include="..\Stripe\Services\Invoices\StripeInvoiceUpdateOptions.cs">
       <Link>Services\Invoices\StripeInvoiceUpdateOptions.cs</Link>
     </Compile>
+    <Compile Include="..\Stripe\Services\Invoices\StripeUpcomingInvoiceLinesOptions.cs">
+      <Link>Services\Invoices\StripeUpcomingInvoiceLinesOptions.cs</Link>
+    </Compile>
     <Compile Include="..\Stripe\Services\Invoices\StripeUpcomingInvoiceOptions.cs">
       <Link>Services\Invoices\StripeUpcomingInvoiceOptions.cs</Link>
     </Compile>

--- a/src/Stripe.Tests/Stripe.Tests.csproj
+++ b/src/Stripe.Tests/Stripe.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="bank_accounts\when_creating_a_bank_account.cs" />
     <Compile Include="card\when_creating_a_card.cs" />
     <Compile Include="charges\when_refunding_and_setting_fraud_details.cs" />
+    <Compile Include="invoices\when_getting_upcoming_invoice_line_items.cs" />
     <Compile Include="Setup.cs" />
     <Compile Include="charges\test_data\stripe_charge_update_options.cs" />
     <Compile Include="charges\when_updating_a_charge.cs" />

--- a/src/Stripe.Tests/invoices/when_getting_upcoming_invoice_line_items.cs
+++ b/src/Stripe.Tests/invoices/when_getting_upcoming_invoice_line_items.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using Machine.Specifications;
+
+namespace Stripe.Tests
+{
+    public class when_getting_upcoming_invoice_line_items
+    {
+        private static StripePlan _stripePlan;
+        private static StripeCustomer _stripeCustomer;
+        private static StripeInvoiceService _stripeInvoiceService;
+        private static StripeInvoiceItemService _stripeInvoiceItemService;
+        private static StripeList<StripeInvoiceLineItem> _stripeInvoiceLineItems;
+        private static StripeInvoiceLineItem _stripeInvoiceItem;
+
+        Establish context = () =>
+        {
+            var stripePlanService = new StripePlanService();
+            var stripePlanCreateOptions = test_data.stripe_plan_create_options.Valid();
+            _stripePlan = stripePlanService.Create(stripePlanCreateOptions);
+
+            var stripeCustomerService = new StripeCustomerService();
+            var stripeCustomerCreateOptions = test_data.stripe_customer_create_options.ValidCard(_stripePlan.Id);
+            _stripeCustomer = stripeCustomerService.Create(stripeCustomerCreateOptions);
+
+            _stripeInvoiceService = new StripeInvoiceService();
+            _stripeInvoiceItemService = new StripeInvoiceItemService();
+
+            _stripeInvoiceItem = _stripeInvoiceItemService.Create(test_data.stripe_invoiceitem_create_options.Valid(_stripeCustomer.Id));
+        };
+
+        Because of = () =>
+            _stripeInvoiceLineItems = _stripeInvoiceService.UpcomingLines(_stripeCustomer.Id);
+
+        It should_have_only_this_pending_invoice_line_item = () =>
+            (_stripeInvoiceLineItems.Data.Single().Id).ShouldEqual(_stripeInvoiceItem.Id);
+
+        
+
+    }
+}

--- a/src/Stripe/Infrastructure/Mapper.cs
+++ b/src/Stripe/Infrastructure/Mapper.cs
@@ -6,6 +6,18 @@ namespace Stripe
 {
     public static class Mapper<T>
     {
+        public static StripeList<T> MapStripeListFromJson(string json, string token = "data")
+        {
+            var list = new StripeList<T>();
+
+            var jObject = JObject.Parse(json);
+
+            var allTokens = jObject.SelectToken(token);
+            list.Data=new List<T>();
+            foreach (var tkn in allTokens)
+                list.Data.Add(MapFromJson(tkn.ToString()));
+            return list;
+        }
         public static List<T> MapCollectionFromJson(string json, string token = "data")
         {
             var list = new List<T>();

--- a/src/Stripe/Services/Invoices/StripeInvoiceService.cs
+++ b/src/Stripe/Services/Invoices/StripeInvoiceService.cs
@@ -29,7 +29,6 @@ namespace Stripe
             );
         }
 
-        //https://api.stripe.com/v1/invoices/upcoming/lines?customer=cus_8Kv2kvdLpEatVh&limit=100
         public virtual StripeList<StripeInvoiceLineItem> UpcomingLines(string customerId, StripeUpcomingInvoiceLinesOptions upcomingOptions = null, StripeRequestOptions requestOptions = null)
         {
             var url = ParameterBuilder.ApplyParameterToUrl($"{Urls.Invoices}/upcoming/lines", "customer", customerId);
@@ -126,6 +125,17 @@ namespace Stripe
                 SetupRequestOptions(requestOptions))
             );
         }
+
+        public virtual async Task<StripeList<StripeInvoiceLineItem>> UpcomingLinesAsync(string customerId, StripeUpcomingInvoiceLinesOptions upcomingOptions = null, StripeRequestOptions requestOptions = null)
+        {
+            var url = ParameterBuilder.ApplyParameterToUrl($"{Urls.Invoices}/upcoming/lines", "customer", customerId);
+
+            return Mapper<StripeInvoiceLineItem>.MapStripeListFromJson(
+                await Requestor.GetStringAsync(this.ApplyAllParameters(upcomingOptions, url, false),
+                SetupRequestOptions(requestOptions))
+            );
+        }
+
 #endif
     }
 }

--- a/src/Stripe/Services/Invoices/StripeInvoiceService.cs
+++ b/src/Stripe/Services/Invoices/StripeInvoiceService.cs
@@ -29,6 +29,17 @@ namespace Stripe
             );
         }
 
+        //https://api.stripe.com/v1/invoices/upcoming/lines?customer=cus_8Kv2kvdLpEatVh&limit=100
+        public virtual StripeList<StripeInvoiceLineItem> UpcomingLines(string customerId, StripeUpcomingInvoiceLinesOptions upcomingOptions = null, StripeRequestOptions requestOptions = null)
+        {
+            var url = ParameterBuilder.ApplyParameterToUrl($"{Urls.Invoices}/upcoming/lines", "customer", customerId);
+
+            return Mapper<StripeInvoiceLineItem>.MapStripeListFromJson(
+                Requestor.GetString(this.ApplyAllParameters(upcomingOptions, url, false),
+                SetupRequestOptions(requestOptions))
+            );
+        }
+
         public virtual StripeInvoice Update(string invoiceId, StripeInvoiceUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
         {
             return Mapper<StripeInvoice>.MapFromJson(

--- a/src/Stripe/Services/Invoices/StripeUpcomingInvoiceLinesOptions.cs
+++ b/src/Stripe/Services/Invoices/StripeUpcomingInvoiceLinesOptions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeUpcomingInvoiceLinesOptions : StripeListOptions
+    {
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+
+        [JsonProperty("coupon")]
+        public string Coupon { get; set; }
+
+        [JsonProperty("subscription")]
+        public string Subscription { get; set; }
+
+        [JsonProperty("subscription_plan")]
+        public string SubscriptionPlan { get; set; }
+
+        [JsonProperty("subscription_prorate")]
+        public string SubscriptionProrate { get; set; }
+
+        [JsonProperty("subscription_proration_date")]
+        public int? SubscriptionProrationDate { get; set; }
+
+        [JsonProperty("subscription_quantity")]
+        public int? SubscriptionQuantity { get; set; }
+
+
+    }
+}

--- a/src/Stripe/Services/Invoices/StripeUpcomingInvoiceLinesOptions.cs
+++ b/src/Stripe/Services/Invoices/StripeUpcomingInvoiceLinesOptions.cs
@@ -5,9 +5,6 @@ namespace Stripe
 {
     public class StripeUpcomingInvoiceLinesOptions : StripeListOptions
     {
-        [JsonProperty("customer")]
-        public string CustomerId { get; set; }
-
         [JsonProperty("coupon")]
         public string Coupon { get; set; }
 

--- a/src/Stripe/Stripe.csproj
+++ b/src/Stripe/Stripe.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Services\BankAccounts\BankAccountCreateOptions.cs" />
     <Compile Include="Services\Charges\StripeChargeUpdateOptions.cs" />
     <Compile Include="Services\Coupons\StripeCouponUpdateOptions.cs" />
+    <Compile Include="Services\Invoices\StripeUpcomingInvoiceLinesOptions.cs" />
     <Compile Include="Services\Invoices\StripeUpcomingInvoiceOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundCreateOptions.cs" />
     <Compile Include="Services\Refunds\StripeRefundService.cs" />


### PR DESCRIPTION
Now includes async and tests. Kept naming convention with Stripe prefix just for consistency. 
