### PR TITLE
Fix to targetFramework value for PCL Target Framework in nuspec

### DIFF
--- a/build/Stripe.net.nuspec
+++ b/build/Stripe.net.nuspec
@@ -13,7 +13,7 @@
     <description>Stripe.net is a sync/async .NET 4.5+ client, and a portable class library for stripe.com.</description>
     <tags>stripe, payment, credit cards, money, gateway, paypal, braintree</tags>
     <dependencies>
-      <group targetFramework="portable-net45+wp8+wpa81">
+      <group targetFramework="portable-net45+win8+wpa81">
         <dependency id="Newtonsoft.Json" version="8.0.3" />
       </group>
       <group targetFramework="net45">
@@ -26,7 +26,7 @@
     <file src="net45\Stripe.net.xml" target="lib\net45" />
     <file src="portable\Stripe.net.dll" target="lib\dotnet" />
     <file src="portable\Stripe.net.xml" target="lib\dotnet" />
-    <file src="portable\Stripe.net.dll" target="lib\portable-net45+wp8+wpa81" />
-    <file src="portable\Stripe.net.pdb" target="lib\portable-net45+wp8+wpa81" />
+    <file src="portable\Stripe.net.dll" target="lib\portable-net45+win8+wpa81" />
+    <file src="portable\Stripe.net.pdb" target="lib\portable-net45+win8+wpa81" />
   </files>
 </package>


### PR DESCRIPTION
The targetFramework value for the PCL in the nuspec file is not a valid value. This leads to the nuget package not being able to be consumed for PCL projects.

https://docs.nuget.org/create/targetframeworks