### PR TITLE
Add property for source transaction

### DIFF
--- a/src/Stripe/Services/Transfers/StripeTransferCreateOptions.cs
+++ b/src/Stripe/Services/Transfers/StripeTransferCreateOptions.cs
@@ -26,6 +26,12 @@ namespace Stripe
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
 
+        /// <summary>
+        /// You can use this parameter to transfer funds from a charge (or other transaction) before they are added to your available balance. A pending balance will transfer immediately but the funds will not become available until the original charge becomes available. See the Connect documentation for details.
+        /// </summary>
+        [JsonProperty("source_transaction")]
+        public string SourceTransaction { get; set; }
+
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
     }


### PR DESCRIPTION
Added source_transaction property to facilitate Special Case Transfers for Stripe connect.

Related ticket #333 