### PR TITLE
Change return type of StripeCustomerService.DeleteAsync from void to Task

### DIFF
--- a/src/Stripe/Services/Customers/StripeCustomerService.cs
+++ b/src/Stripe/Services/Customers/StripeCustomerService.cs
@@ -72,7 +72,7 @@ namespace Stripe
             );
         }
 
-        public virtual async void DeleteAsync(string customerId, StripeRequestOptions requestOptions = null)
+        public virtual async Task DeleteAsync(string customerId, StripeRequestOptions requestOptions = null)
         {
             await Requestor.DeleteAsync($"{Urls.Customers}/{customerId}",
                 SetupRequestOptions(requestOptions));


### PR DESCRIPTION
Hello,

The DeleteAsync function in StripeCustomerService was returning void and therefore could not be awaited, just changed the return type to Task.

