### PR TITLE
add missing transfer_statement_descriptor

### DIFF
--- a/src/Stripe/Entities/StripeAccount.cs
+++ b/src/Stripe/Entities/StripeAccount.cs
@@ -88,6 +88,9 @@ namespace Stripe
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
 
+        [JsonProperty("transfer_statement_descriptor")]
+        public string TransferStatementDescriptor { get; set; }
+        
         [JsonProperty("support_email")]
         public string SupportEmail { get; set; }
 


### PR DESCRIPTION
Now Stripe returns transfer_statement_descriptor when retrieving an Account.