### PR TITLE
include 'source_type': The source balance this transfer came from. On…

### DIFF
--- a/src/Stripe.net/Services/Transfers/StripeTransferCreateOptions.cs
+++ b/src/Stripe.net/Services/Transfers/StripeTransferCreateOptions.cs
@@ -37,6 +37,9 @@ namespace Stripe
         [JsonProperty("source_transaction")]
         public string SourceTransaction { get; set; }
 
+        [JsonProperty("source_type")]
+        public string SourceType { get; set; }
+
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
     }


### PR DESCRIPTION
This is needed in the context of some transfer types. 

See:
https://stripe.com/docs/api#transfer_object

```
source_type string
The source balance this transfer came from. 
One of card, bank_account, bitcoin_receiver, or alipay_account
```