### PR TITLE
Removed CustomerId for Subscriptions and added StripeSubscriptionListOptions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 7.0.3.{build}
+version: 7.0.4.{build}
 image: Visual Studio 2015
 
 environment:

--- a/readme.md
+++ b/readme.md
@@ -1201,28 +1201,28 @@ Subscriptions
 
 ```csharp
 	var subscriptionService = new StripeSubscriptionService();
-	StripeSubscription stripeSubscription = subscriptionService.Update(*customerId*, *subscriptionId*); // optional StripeSubscriptionUpdateOptions
+	StripeSubscription stripeSubscription = subscriptionService.Update(*subscriptionId*); // optional StripeSubscriptionUpdateOptions
 ```
 
 ### Retrieving a subscription
 
 ```csharp
 	var subscriptionService = new StripeSubscriptionService();
-	StripeSubscription stripeSubscription = subscriptionService.Get(*customerId*, *subscriptionId*);
+	StripeSubscription stripeSubscription = subscriptionService.Get(*subscriptionId*);
 ```
 
 ### Canceling a subscription
 
 ```csharp
 	var subscriptionService = new StripeSubscriptionService();
-	subscriptionService.Cancel(*customerId*, *subscriptionId*); // optional cancelAtPeriodEnd flag
+	subscriptionService.Cancel(*subscriptionId*); // optional cancelAtPeriodEnd flag
 ```
 
-### List all subscriptions for a customer
+### List all subscriptions
 
 ```csharp
 	var subscriptionService = new StripeSubscriptionService();
-	IEnumerable<StripeSubscription> response = subscriptionService.List(*customerId*); // optional StripeListOptions
+	IEnumerable<StripeSubscription> response = subscriptionService.List(); // optional StripeSubscriptionListOptions
 ```
 
 [StripeListOptions](#stripelistoptions-paging) for paging

--- a/src/Stripe.net.Tests/connect/when_listing_subscriptions_on_another_account.cs
+++ b/src/Stripe.net.Tests/connect/when_listing_subscriptions_on_another_account.cs
@@ -25,7 +25,7 @@ namespace Stripe.Tests
         Because of = () =>
         {
             var requestOptions = new StripeRequestOptions() { StripeConnectAccountId = _connectedAccountId };
-            _stripeSubscriptionList = _stripeSubscriptionService.List(_connectedAccountCustomerId, null, requestOptions).ToList();
+            _stripeSubscriptionList = _stripeSubscriptionService.List(new StripeSubscriptionListOptions { CustomerId = _connectedAccountCustomerId }, requestOptions).ToList();
         };
 
         It should_have_at_lest_one_subscription = () =>

--- a/src/Stripe.net.Tests/discounts/when_deleting_a_discount_from_a_subscription.cs
+++ b/src/Stripe.net.Tests/discounts/when_deleting_a_discount_from_a_subscription.cs
@@ -22,7 +22,7 @@ namespace Stripe.Tests
             var customerService = new StripeCustomerService();
             _customer = customerService.Create(test_data.stripe_customer_create_options.ValidCard(plan.Id));
 
-            _subscription = new StripeSubscriptionService().Update(_customer.Id, 
+            _subscription = new StripeSubscriptionService().Update( 
                 _customer.Subscriptions.Data[0].Id,
                 new StripeSubscriptionUpdateOptions()
                 {

--- a/src/Stripe.net.Tests/discounts/when_deleting_a_discount_from_a_subscription_async.cs
+++ b/src/Stripe.net.Tests/discounts/when_deleting_a_discount_from_a_subscription_async.cs
@@ -22,7 +22,7 @@ namespace Stripe.Tests
             var customerService = new StripeCustomerService();
             _customer = customerService.Create(test_data.stripe_customer_create_options.ValidCard(plan.Id));
 
-            _subscription = new StripeSubscriptionService().Update(_customer.Id, 
+            _subscription = new StripeSubscriptionService().Update( 
                 _customer.Subscriptions.Data[0].Id,
                 new StripeSubscriptionUpdateOptions()
                 {

--- a/src/Stripe.net.Tests/subscriptions/when_canceling_a_subscription.cs
+++ b/src/Stripe.net.Tests/subscriptions/when_canceling_a_subscription.cs
@@ -25,7 +25,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Cancel(_stripeCustomer.Id, _stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id);
+            _stripeSubscription = _stripeSubscriptionService.Cancel(_stripeSubscriptionService.List(new StripeSubscriptionListOptions { CustomerId = _stripeCustomer.Id }).ToList()[0].Id);
 
         It should_be_a_canceled_subscription = () =>
             _stripeSubscription.Status.ShouldEqual("canceled");

--- a/src/Stripe.net.Tests/subscriptions/when_canceling_a_subscription_and_trying_to_retrieve.cs
+++ b/src/Stripe.net.Tests/subscriptions/when_canceling_a_subscription_and_trying_to_retrieve.cs
@@ -26,11 +26,11 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Cancel(_stripeCustomer.Id, _stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, false);
+            _stripeSubscription = _stripeSubscriptionService.Cancel(_stripeSubscriptionService.List(new StripeSubscriptionListOptions { CustomerId = _stripeCustomer.Id }).ToList()[0].Id, false);
 
         It should_throw_exception_when_retrieved = () =>
         {
-            var exception = Catch.Exception(() => _stripeSubscriptionService.Get(_stripeCustomer.Id, _stripeSubscription.Id));
+            var exception = Catch.Exception(() => _stripeSubscriptionService.Get(_stripeSubscription.Id));
             exception.Message.ShouldNotBeNull(); 
         };
     }

--- a/src/Stripe.net.Tests/subscriptions/when_changing_a_subscription_plan.cs
+++ b/src/Stripe.net.Tests/subscriptions/when_changing_a_subscription_plan.cs
@@ -31,7 +31,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Update(_stripeCustomer.Id, _stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
+            _stripeSubscription = _stripeSubscriptionService.Update(_stripeSubscriptionService.List(new StripeSubscriptionListOptions { CustomerId = _stripeCustomer.Id }).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
 
         It should_have_the_same_id_as_the_new_plan = () =>
             _stripeSubscription.StripePlan.Id.ShouldEqual(_stripePlan2.Id);

--- a/src/Stripe.net.Tests/subscriptions/when_getting_a_subscription.cs
+++ b/src/Stripe.net.Tests/subscriptions/when_getting_a_subscription.cs
@@ -25,7 +25,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Get(_stripeCustomer.Id, _stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id);
+            _stripeSubscription = _stripeSubscriptionService.Get(_stripeSubscriptionService.List(new StripeSubscriptionListOptions { CustomerId = _stripeCustomer.Id }).ToList()[0].Id);
 
         It should_get_the_same_subscription = () =>
             _stripeSubscription.ShouldNotBeNull();

--- a/src/Stripe.net.Tests/subscriptions/when_listing_subscriptions.cs
+++ b/src/Stripe.net.Tests/subscriptions/when_listing_subscriptions.cs
@@ -26,7 +26,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscriptionList = _stripeSubscriptionService.List(_stripeCustomer.Id).ToList();
+            _stripeSubscriptionList = _stripeSubscriptionService.List(new StripeSubscriptionListOptions { CustomerId = _stripeCustomer.Id }).ToList();
 
         It should_have_one_subscription = () =>
             _stripeSubscriptionList.Count().ShouldEqual(1);

--- a/src/Stripe.net.Tests/subscriptions/when_updating_a_subscription.cs
+++ b/src/Stripe.net.Tests/subscriptions/when_updating_a_subscription.cs
@@ -29,7 +29,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Update(_stripeCustomer.Id, _stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
+            _stripeSubscription = _stripeSubscriptionService.Update(_stripeSubscriptionService.List(new StripeSubscriptionListOptions { CustomerId = _stripeCustomer.Id }).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
 
         It should_have_the_new_quantity = () =>
             _stripeSubscription.Quantity.ShouldEqual(5);

--- a/src/Stripe.net.Tests/subscriptions/when_updating_a_subscription_with_proration.cs
+++ b/src/Stripe.net.Tests/subscriptions/when_updating_a_subscription_with_proration.cs
@@ -35,7 +35,7 @@ namespace Stripe.Tests
                 Quantity = 2,
             };
 
-            _subscription = _subscriptionService.Update(_customerId, _subscription.Id, updateOptions);
+            _subscription = _subscriptionService.Update(_subscription.Id, updateOptions);
 
             _upcomingInvoice = new StripeInvoiceService().Upcoming(_customerId, new StripeUpcomingInvoiceOptions() { SubscriptionId = _subscription.Id });
         };

--- a/src/Stripe.net.Tests/subscriptions/when_updating_trial_end_date_subscription.cs
+++ b/src/Stripe.net.Tests/subscriptions/when_updating_trial_end_date_subscription.cs
@@ -30,7 +30,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Update(_stripeCustomer.Id, _stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
+            _stripeSubscription = _stripeSubscriptionService.Update(_stripeSubscriptionService.List(new StripeSubscriptionListOptions { CustomerId = _stripeCustomer.Id }).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
 
         It should_return_text_version_of_date_for_internal_trialend = () =>
             _stripeSubscriptionUpdateOptions.TrialEndInternal.ShouldEqual(EpochTime.ConvertDateTimeToEpoch(_stripeSubscriptionUpdateOptions.TrialEnd.Value).ToString());

--- a/src/Stripe.net.Tests/subscriptions/when_updating_trial_end_of_subscription.cs
+++ b/src/Stripe.net.Tests/subscriptions/when_updating_trial_end_of_subscription.cs
@@ -29,7 +29,7 @@ namespace Stripe.Tests
         };
 
         Because of = () =>
-            _stripeSubscription = _stripeSubscriptionService.Update(_stripeCustomer.Id, _stripeSubscriptionService.List(_stripeCustomer.Id).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
+            _stripeSubscription = _stripeSubscriptionService.Update(_stripeSubscriptionService.List(new StripeSubscriptionListOptions { CustomerId = _stripeCustomer.Id }).ToList()[0].Id, _stripeSubscriptionUpdateOptions);
 
         It should_return_now_for_internal_trialend = () =>
             _stripeSubscriptionUpdateOptions.TrialEndInternal.ShouldEqual("now");

--- a/src/Stripe.net/Infrastructure/Urls.cs
+++ b/src/Stripe.net/Infrastructure/Urls.cs
@@ -34,7 +34,7 @@
 
         public static string Recipients => BaseUrl + "/recipients";
 
-        public static string Subscriptions => BaseUrl + "/customers/{0}/subscriptions";
+        public static string Subscriptions => BaseUrl + "/subscriptions";
 
         public static string Transfers => BaseUrl + "/transfers";
 

--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionListOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionListOptions.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeSubscriptionListOptions : StripeListOptions
+    {
+        [JsonProperty("created")]
+        public StripeDateFilter Created { get; set; }
+
+        [JsonProperty("plan")]
+        public string PlanId { get; set; }
+
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+
+        /// <summary>
+        /// The status of the subscriptions to retrieve. You can specify "all" or one of the <see cref="StripeSubscriptionStatuses"/>
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionService.Obsolete.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionService.Obsolete.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Stripe
+{
+    public partial class StripeSubscriptionService
+    {
+        //Sync
+        [Obsolete("Get with customerId is deprecated, use Get without the customerId.")]
+        public virtual StripeSubscription Get(string customerId, string subscriptionId, StripeRequestOptions requestOptions = null)
+        {
+            return Get(subscriptionId, requestOptions);
+        }
+
+        [Obsolete("Update with customerId is deprecated, use Update without the customerId.")]
+        public virtual StripeSubscription Update(string customerId, string subscriptionId, StripeSubscriptionUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
+        {
+            return Update(subscriptionId, updateOptions, requestOptions);
+        }
+
+        [Obsolete("Cancel with customerId is deprecated, use Cancel without the customerId.")]
+        public virtual StripeSubscription Cancel(string customerId, string subscriptionId, bool cancelAtPeriodEnd = false, StripeRequestOptions requestOptions = null)
+        {
+            return Cancel(subscriptionId, cancelAtPeriodEnd, requestOptions);
+        }
+
+        [Obsolete("List with customerId is deprecated, use List without the customerId.")]
+        public virtual IEnumerable<StripeSubscription> List(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        {
+            var options = new StripeSubscriptionListOptions
+            {
+                CustomerId = customerId
+            };
+
+            if (listOptions != null)
+            {
+                options.EndingBefore = listOptions.EndingBefore;
+                options.StartingAfter = listOptions.StartingAfter;
+                options.Limit = listOptions.Limit;
+            }
+
+            return List(options, requestOptions);
+        }
+
+
+
+        //Async
+        [Obsolete("GetAsync with customerId is deprecated, use GetAsync without the customerId.")]
+        public virtual async Task<StripeSubscription> GetAsync(string customerId, string subscriptionId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await GetAsync(subscriptionId, requestOptions, cancellationToken);
+        }
+
+        [Obsolete("UpdateAsync with customerId is deprecated, use UpdateAsync without the customerId.")]
+        public virtual async Task<StripeSubscription> UpdateAsync(string customerId, string subscriptionId, StripeSubscriptionUpdateOptions updateOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await UpdateAsync(subscriptionId, updateOptions, requestOptions, cancellationToken);
+        }
+
+        [Obsolete("CancelAsync with customerId is deprecated, use CancelAsync without the customerId.")]
+        public virtual async Task<StripeSubscription> CancelAsync(string customerId, string subscriptionId, bool cancelAtPeriodEnd = false, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await CancelAsync(subscriptionId, cancelAtPeriodEnd, requestOptions, cancellationToken);
+        }
+
+        [Obsolete("ListAsync with customerId is deprecated, use ListAsync without the customerId.")]
+        public virtual async Task<IEnumerable<StripeSubscription>> ListAsync(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var options = new StripeSubscriptionListOptions
+            {
+                CustomerId = customerId
+            };
+
+            if (listOptions != null)
+            {
+                options.EndingBefore = listOptions.EndingBefore;
+                options.StartingAfter = listOptions.StartingAfter;
+                options.Limit = listOptions.Limit;
+            }
+
+            return await ListAsync(options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionService.cs
@@ -5,7 +5,7 @@ using Stripe.Infrastructure;
 
 namespace Stripe
 {
-    public class StripeSubscriptionService : StripeService
+    public partial class StripeSubscriptionService : StripeService
     {
         public StripeSubscriptionService(string apiKey = null) : base(apiKey) { }
 
@@ -14,9 +14,9 @@ namespace Stripe
 
 
         //Sync
-        public virtual StripeSubscription Get(string customerId, string subscriptionId, StripeRequestOptions requestOptions = null)
+        public virtual StripeSubscription Get(string subscriptionId, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions + "/{1}", customerId, subscriptionId);
+            var url = string.Format(Urls.Subscriptions + "/{0}", subscriptionId);
 
             return Mapper<StripeSubscription>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(null, url, false),
@@ -26,8 +26,8 @@ namespace Stripe
 
         public virtual StripeSubscription Create(string customerId, string planId, StripeSubscriptionCreateOptions createOptions = null, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions, customerId);
-            url = this.ApplyAllParameters(createOptions, url, false);
+            var url = this.ApplyAllParameters(createOptions, Urls.Subscriptions, false);
+            url = ParameterBuilder.ApplyParameterToUrl(url, "customer", customerId);
 
             return Mapper<StripeSubscription>.MapFromJson(
                 Requestor.PostString(ParameterBuilder.ApplyParameterToUrl(url, "plan", planId),
@@ -35,9 +35,9 @@ namespace Stripe
             );
         }
 
-        public virtual StripeSubscription Update(string customerId, string subscriptionId, StripeSubscriptionUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
+        public virtual StripeSubscription Update(string subscriptionId, StripeSubscriptionUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions + "/{1}", customerId, subscriptionId);
+            var url = string.Format(Urls.Subscriptions + "/{0}", subscriptionId);
 
             return Mapper<StripeSubscription>.MapFromJson(
                 Requestor.PostString(this.ApplyAllParameters(updateOptions, url, false),
@@ -45,9 +45,9 @@ namespace Stripe
             );
         }
 
-        public virtual StripeSubscription Cancel(string customerId, string subscriptionId, bool cancelAtPeriodEnd = false, StripeRequestOptions requestOptions = null)
+        public virtual StripeSubscription Cancel(string subscriptionId, bool cancelAtPeriodEnd = false, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions + "/{1}", customerId, subscriptionId);
+            var url = string.Format(Urls.Subscriptions + "/{0}", subscriptionId);
             url = ParameterBuilder.ApplyParameterToUrl(url, "at_period_end", cancelAtPeriodEnd.ToString());
 
             return Mapper<StripeSubscription>.MapFromJson(
@@ -56,12 +56,10 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<StripeSubscription> List(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual IEnumerable<StripeSubscription> List(StripeSubscriptionListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            var url = string.Format(Urls.Subscriptions, customerId);
-
             return Mapper<StripeSubscription>.MapCollectionFromJson(
-                Requestor.GetString(this.ApplyAllParameters(listOptions, url, true),
+                Requestor.GetString(this.ApplyAllParameters(listOptions, Urls.Subscriptions, true),
                 SetupRequestOptions(requestOptions))
             );
         }
@@ -69,9 +67,9 @@ namespace Stripe
 
 
         //Async
-        public virtual async Task<StripeSubscription> GetAsync(string customerId, string subscriptionId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeSubscription> GetAsync(string subscriptionId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var url = string.Format(Urls.Subscriptions + "/{1}", customerId, subscriptionId);
+            var url = string.Format(Urls.Subscriptions + "/{0}", subscriptionId);
 
             return Mapper<StripeSubscription>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(null, url, false),
@@ -82,8 +80,8 @@ namespace Stripe
 
         public virtual async Task<StripeSubscription> CreateAsync(string customerId, string planId, StripeSubscriptionCreateOptions createOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var url = string.Format(Urls.Subscriptions, customerId);
-            url = this.ApplyAllParameters(createOptions, url, false);
+            var url = this.ApplyAllParameters(createOptions, Urls.Subscriptions, false);
+            url = ParameterBuilder.ApplyParameterToUrl(url, "customer", customerId);
 
             return Mapper<StripeSubscription>.MapFromJson(
                 await Requestor.PostStringAsync(ParameterBuilder.ApplyParameterToUrl(url, "plan", planId),
@@ -92,9 +90,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<StripeSubscription> UpdateAsync(string customerId, string subscriptionId, StripeSubscriptionUpdateOptions updateOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeSubscription> UpdateAsync(string subscriptionId, StripeSubscriptionUpdateOptions updateOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var url = string.Format(Urls.Subscriptions + "/{1}", customerId, subscriptionId);
+            var url = string.Format(Urls.Subscriptions + "/{0}", subscriptionId);
 
             return Mapper<StripeSubscription>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, url, false),
@@ -103,9 +101,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<StripeSubscription> CancelAsync(string customerId, string subscriptionId, bool cancelAtPeriodEnd = false, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeSubscription> CancelAsync(string subscriptionId, bool cancelAtPeriodEnd = false, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var url = string.Format(Urls.Subscriptions + "/{1}", customerId, subscriptionId);
+            var url = string.Format(Urls.Subscriptions + "/{0}", subscriptionId);
             url = ParameterBuilder.ApplyParameterToUrl(url, "at_period_end", cancelAtPeriodEnd.ToString());
 
             return Mapper<StripeSubscription>.MapFromJson(
@@ -115,15 +113,13 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<StripeSubscription>> ListAsync(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<IEnumerable<StripeSubscription>> ListAsync(StripeSubscriptionListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var url = string.Format(Urls.Subscriptions, customerId);
-
             return Mapper<StripeSubscription>.MapCollectionFromJson(
-                await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, url, true),
+                await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Subscriptions, true),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );
         }
-   }
+    }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -20,6 +20,9 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+
         [JsonProperty("plan")]
         public string PlanId { get; set; }
 

--- a/src/Stripe.net/project.json
+++ b/src/Stripe.net/project.json
@@ -54,7 +54,7 @@
     "tags": [ "stripe", "payment", "credit", "cards", "money", "gateway", "paypal", "braintree" ]
   },
   "title": "Stripe.net",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "runtimes": {
     "win10-x64": {}
   }


### PR DESCRIPTION
Removed requirement for `customerId` in `StripeSubscriptionService` 
Added `StripeSubscriptionListOptions` to provide support for API 2016-07-06 changes
resolves #722 
resolves #585 