### PR TITLE
Added List and ListAsync methods to StripeAccountService

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,15 @@ Updating an account has almost all the same available properties as creating an 
 	accountService.Delete(*accountId*);
 ```
 
+### List all accounts
+
+```csharp
+	var accountService = new StripeAccountService();
+	IEnumerable<StripeAccount> response = accountService.List(); // optional StripeListOptions
+```
+
+[StripeListOptions](#stripelistoptions-paging) for paging
+
 Application Fees
 ----------------
 

--- a/src/Stripe.net.Tests.XUnit/accounts/listing_external_accounts.cs
+++ b/src/Stripe.net.Tests.XUnit/accounts/listing_external_accounts.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.xUnit
+{
+    public class listing_external_accounts : test
+    {
+        private IEnumerable<StripeAccount> DefaultLimitAllRetrievedAccounts { get; }
+        private IEnumerable<StripeAccount> Limit4RetrievedAccounts { get; }
+
+        public listing_external_accounts()
+        {
+            var newAccount = new StripeAccountService(_stripe_api_key).Create(
+                new StripeAccountCreateOptions
+                {
+                    BusinessName = "Subtracts",
+                    BusinessPrimaryColor = "#" + new Random().Next(0, 6).ToString("D6"),
+                    BusinessUrl = "http://subtracts.io",
+                    DebitNegativeBalances = true,
+                    DeclineChargeOnAvsFailure = false,
+                    DeclineChargeOnCvcFailure = true,
+                    DefaultCurrency = "usd",
+                    Email = $"some_test@someotheremail.com",
+                    Managed = true,
+                    ExternalCardAccount = new StripeAccountCardOptions()
+                    {
+                        AddressCountry = "US",
+                        AddressLine1 = "24 Main St",
+                        AddressLine2 = "Apt 24",
+                        AddressCity = "Raleigh",
+                        AddressState = "NC",
+                        AddressZip = "27617",
+                        Cvc = "1223",
+                        ExpirationMonth = "10",
+                        ExpirationYear = "2021",
+                        Name = "Joe Meatballs",
+                        Number = "4000056655665556",
+                        Currency = "usd",
+                        DefaultForCurrency = true
+                    }
+                }
+            );
+
+            DefaultLimitAllRetrievedAccounts = new StripeAccountService(_stripe_api_key).List();
+
+            Limit4RetrievedAccounts = new StripeAccountService(_stripe_api_key).List(new StripeListOptions { Limit = 4 });
+        }
+
+        [Fact]
+        public void has_default_limit_min_total_count()
+        {
+            DefaultLimitAllRetrievedAccounts.ToList().Count().Should().BeGreaterOrEqualTo(1);
+        }
+
+        [Fact]
+        public void has_default_limit_max_total_count()
+        {
+            DefaultLimitAllRetrievedAccounts.ToList().Count().Should().BeLessOrEqualTo(10);
+        }
+
+        [Fact]
+        public void has_specified_limit_min_total_count()
+        {
+            Limit4RetrievedAccounts.ToList().Count().Should().BeGreaterOrEqualTo(1);
+        }
+
+        [Fact]
+        public void has_specified_limit_max_total_count()
+        {
+            Limit4RetrievedAccounts.ToList().Count().Should().BeLessOrEqualTo(4);
+        }
+    }
+}
+

--- a/src/Stripe.net/Services/Account/StripeAccountService.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Stripe.Infrastructure;
+using System.Collections.Generic;
 
 namespace Stripe
 {
@@ -15,6 +16,16 @@ namespace Stripe
         {
             return Mapper<StripeAccount>.MapFromJson(
                 Requestor.PostString(this.ApplyAllParameters(createOptions, $"{Urls.BaseUrl}/accounts", false),
+                SetupRequestOptions(requestOptions))
+            );
+        }
+
+        public virtual IEnumerable<StripeAccount> List(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        {
+            var path = $"{Urls.BaseUrl}/accounts";
+
+            return Mapper<StripeAccount>.MapCollectionFromJson(
+                Requestor.GetString(this.ApplyAllParameters(listOptions, path, false),
                 SetupRequestOptions(requestOptions))
             );
         }
@@ -57,6 +68,17 @@ namespace Stripe
         {
             return Mapper<StripeAccount>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, "{Urls.BaseUrl}/accounts", false),
+                SetupRequestOptions(requestOptions),
+                cancellationToken)
+            );
+        }
+
+        public virtual async Task<IEnumerable<StripeAccount>> ListAsync(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var path = $"{Urls.BaseUrl}/accounts";
+
+            return Mapper<StripeAccount>.MapCollectionFromJson(
+                await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, path, false),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );

--- a/src/Stripe.net/Services/Account/StripeAccountService.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountService.cs
@@ -67,7 +67,7 @@ namespace Stripe
         public virtual async Task<StripeAccount> CreateAsync(StripeAccountCreateOptions createOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeAccount>.MapFromJson(
-                await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, "{Urls.BaseUrl}/accounts", false),
+                await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, $"{Urls.BaseUrl}/accounts", false),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );


### PR DESCRIPTION
Added List and ListAsync methods to StripeAccountService, along with unit tests and readme update. Also fixed a bug that prevented StripeAccountService.CreateAsync from working.

This allows the listing of all connected accounts, useful in my case for the maintenance of stored credit cards. I want to delete all saved credit cards from all connected accounts within a certain time period, and needed a way to iterate through all connected accounts on a nightly basis.

I was thinking about adding some kind of list iterator to Stripe.net to automatically iterate through all connected accounts (100 at a time, as 100 is the max list limit in Stripe API), which could also work with other returned lists, but I didn't want to make architectural presumptions on how you would like to structure that in this project (this being my first pull request to it), so for now I will do that in my client code.
