### PR TITLE
Adds support for specifying no additional owners

### DIFF
--- a/src/Stripe.net.Tests.XUnit/accounts/when_no_additional_owners.cs
+++ b/src/Stripe.net.Tests.XUnit/accounts/when_no_additional_owners.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using Stripe.Infrastructure;
+using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.xUnit
+{
+    public class when_no_additional_owners : test
+    {
+        private StripeAccountCreateOptions AccountOptions { get; }
+        private String AccountJSON { get; }
+
+        public when_no_additional_owners()
+        {
+            AccountOptions =
+                new StripeAccountCreateOptions
+                {
+                    Email = $"merry@christmas.com",
+                    Managed = true,
+                    LegalEntity = new StripeAccountLegalEntityOptions
+                    {
+                        AdditionalOwners = new List<StripeAccountAdditionalOwner> { }
+                    }
+                };
+        }
+
+        [Fact]
+        public void has_legal_entity()
+        {
+            var accountString = new StripeAccountService(_stripe_api_key).ApplyAllParameters(AccountOptions, $"{Urls.BaseUrl}/accounts", false);
+            accountString.Should().Contain("legal_entity[additional_owners]");
+        }
+    }
+}
+

--- a/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/AdditionalOwnerPlugin.cs
+++ b/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/AdditionalOwnerPlugin.cs
@@ -12,8 +12,15 @@ namespace Stripe.Infrastructure.Middleware
             if (attribute.PropertyName != "legal_entity[additional_owners]") return false;
 
             var owners = ((List<StripeAccountAdditionalOwner>) property.GetValue(propertyParent, null));
-            if (owners == null) return true;
 
+            if (owners == null) return true;
+            if (owners.Count == 0)
+            {
+                RequestStringBuilder.ApplyParameterToRequestString(ref requestString,
+                    attribute.PropertyName,
+                    "");
+                return true;
+            }
             var ownerIndex = 0;
 
             foreach (var owner in owners)

--- a/src/Stripe.net/Properties/InternalsVisibleTo.cs
+++ b/src/Stripe.net/Properties/InternalsVisibleTo.cs
@@ -1,3 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Stripe.net.Tests")]
+[assembly: InternalsVisibleTo("Stripe.net.Tests.xUnit")]

--- a/src/Stripe.net/Services/Account/StripeAccountService.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountService.cs
@@ -10,7 +10,6 @@ namespace Stripe
         public StripeAccountService(string apiKey = null) : base(apiKey) { }
 
 
-
         //Sync
         public virtual StripeAccount Create(StripeAccountCreateOptions createOptions, StripeRequestOptions requestOptions = null)
         {


### PR DESCRIPTION
This PR addresses #718 and allows for setting the additional_parameters field to null on a managed account. The proposed syntax is:
`AdditionalOwners = new List<StripeAccountAdditionalOwner> { }`
