### PR TITLE
stripe.net tests now run with the STRIPE_TEST_KEY environment variable (sk_test_xxxxx)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image: Visual Studio 2017
 environment:
   STRIPE_TEST_KEY:
     secure: +p/EWA8+0B64k7a88nb6ZiSTcv6TIukyhQQU2Ljf7jNVtwVZXhJtNf5LdemV7EuY
-  STRIPE_RECIPIENT_TEST_KEY:
+  STRIPE_TEST_KEY_RECIPIENT:
     secure: +eN5/SMeEbaqOR5VeM62dIJ8CGEzb74+3+feLb60jnYhQJ5enX2IwdFyfIy6/5UZ
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image: Visual Studio 2017
 environment:
   STRIPE_TEST_KEY:
     secure: +p/EWA8+0B64k7a88nb6ZiSTcv6TIukyhQQU2Ljf7jNVtwVZXhJtNf5LdemV7EuY
-  STRIPE_TEST_KEY_RECIPIENT:
+  STRIPE_RECIPIENT_KEY:
     secure: +eN5/SMeEbaqOR5VeM62dIJ8CGEzb74+3+feLb60jnYhQJ5enX2IwdFyfIy6/5UZ
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,10 @@ version: 7.7.0.{build}
 image: Visual Studio 2017
 
 environment:
-  stripe_test_secret_key:
+  STRIPE_TEST_KEY:
     secure: +p/EWA8+0B64k7a88nb6ZiSTcv6TIukyhQQU2Ljf7jNVtwVZXhJtNf5LdemV7EuY
+  STRIPE_RECIPIENT_TEST_KEY:
+    secure: +eN5/SMeEbaqOR5VeM62dIJ8CGEzb74+3+feLb60jnYhQJ5enX2IwdFyfIy6/5UZ
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.Tests.XUnit/Cache.cs
+++ b/src/Stripe.Tests.XUnit/Cache.cs
@@ -18,6 +18,6 @@ namespace Stripe.Tests.Xunit
         /// </summary>
         public static Dictionary<string, object> Items { get; set; }
 
-        public static string ApiKey => Environment.GetEnvironmentVariable("stripe_test_secret_key");
+        public static string ApiKey => Environment.GetEnvironmentVariable("STRIPE_TEST_KEY");
     }
 }

--- a/src/Stripe.Tests.XUnit/Cache.cs
+++ b/src/Stripe.Tests.XUnit/Cache.cs
@@ -19,5 +19,6 @@ namespace Stripe.Tests.Xunit
         public static Dictionary<string, object> Items { get; set; }
 
         public static string ApiKey => Environment.GetEnvironmentVariable("STRIPE_TEST_KEY");
+        public static string RecipientApiKey => Environment.GetEnvironmentVariable("STRIPE_TEST_KEY_RECIPIENT");
     }
 }

--- a/src/Stripe.Tests.XUnit/Cache.cs
+++ b/src/Stripe.Tests.XUnit/Cache.cs
@@ -19,6 +19,6 @@ namespace Stripe.Tests.Xunit
         public static Dictionary<string, object> Items { get; set; }
 
         public static string ApiKey => Environment.GetEnvironmentVariable("STRIPE_TEST_KEY");
-        public static string RecipientApiKey => Environment.GetEnvironmentVariable("STRIPE_TEST_KEY_RECIPIENT");
+        public static string RecipientApiKey => Environment.GetEnvironmentVariable("STRIPE_RECIPIENT_KEY");
     }
 }

--- a/src/Stripe.net.Tests/Cache.cs
+++ b/src/Stripe.net.Tests/Cache.cs
@@ -5,6 +5,9 @@ namespace Stripe.Tests
 {
     public static class Cache
     {
+        public static string RecipientApiKey => Environment.GetEnvironmentVariable("STRIPE_RECIPIENT_KEY");
+
+
         public static StripeAccountCreateOptions ManagedAccountWithCardOptions { get; set; }
         public static StripeAccountCreateOptions ManagedAccountWithBankAccountOptions { get; set; }
 

--- a/src/Stripe.net.Tests/Cache.cs
+++ b/src/Stripe.net.Tests/Cache.cs
@@ -5,7 +5,7 @@ namespace Stripe.Tests
 {
     public static class Cache
     {
-        public static string RecipientApiKey => Environment.GetEnvironmentVariable("STRIPE_RECIPIENT_KEY");
+        public static string RecipientApiKey => Environment.GetEnvironmentVariable("STRIPE_TEST_KEY_RECIPIENT");
 
 
         public static StripeAccountCreateOptions ManagedAccountWithCardOptions { get; set; }

--- a/src/Stripe.net.Tests/Cache.cs
+++ b/src/Stripe.net.Tests/Cache.cs
@@ -5,7 +5,7 @@ namespace Stripe.Tests
 {
     public static class Cache
     {
-        public static string RecipientApiKey => Environment.GetEnvironmentVariable("STRIPE_TEST_KEY_RECIPIENT");
+        public static string RecipientApiKey => Environment.GetEnvironmentVariable("STRIPE_RECIPIENT_KEY");
 
 
         public static StripeAccountCreateOptions ManagedAccountWithCardOptions { get; set; }

--- a/src/Stripe.net.Tests/Setup.cs
+++ b/src/Stripe.net.Tests/Setup.cs
@@ -7,17 +7,14 @@ namespace Stripe.Tests
     {
         void IAssemblyContext.OnAssemblyStart()
         {
-            var apiKey = "stripe_test_secret_key";
+            var envKey = Environment.GetEnvironmentVariable("STRIPE_TEST_KEY");
 
-            var envKey = Environment.GetEnvironmentVariable("stripe_test_secret_key");
-            if (!string.IsNullOrEmpty(envKey)) apiKey = envKey;
-
-            StripeConfiguration.SetApiKey(apiKey);
+            StripeConfiguration.SetApiKey(envKey);
         }
 
         void IAssemblyContext.OnAssemblyComplete()
         {
-            // great, we're done!
+            // great, we're done! nothing to cleanup.
         }
     }
 }

--- a/src/Stripe.net.Tests/Setup.cs
+++ b/src/Stripe.net.Tests/Setup.cs
@@ -7,10 +7,7 @@ namespace Stripe.Tests
     {
         void IAssemblyContext.OnAssemblyStart()
         {
-            // using this temporarily while the main test account is deleting test data
-            var envKey = Environment.GetEnvironmentVariable("STRIPE_TEST_KEY_RECIPIENT");
-
-            //var envKey = Environment.GetEnvironmentVariable("STRIPE_TEST_KEY");
+            var envKey = Environment.GetEnvironmentVariable("STRIPE_TEST_KEY");
 
             StripeConfiguration.SetApiKey(envKey);
         }

--- a/src/Stripe.net.Tests/Setup.cs
+++ b/src/Stripe.net.Tests/Setup.cs
@@ -8,7 +8,7 @@ namespace Stripe.Tests
         void IAssemblyContext.OnAssemblyStart()
         {
             // using this temporarily while the main test account is deleting test data
-            var envKey = Environment.GetEnvironmentVariable("STRIPE_RECIPIENT_KEY");
+            var envKey = Environment.GetEnvironmentVariable("STRIPE_TEST_KEY_RECIPIENT");
 
             //var envKey = Environment.GetEnvironmentVariable("STRIPE_TEST_KEY");
 

--- a/src/Stripe.net.Tests/Setup.cs
+++ b/src/Stripe.net.Tests/Setup.cs
@@ -7,7 +7,10 @@ namespace Stripe.Tests
     {
         void IAssemblyContext.OnAssemblyStart()
         {
-            var envKey = Environment.GetEnvironmentVariable("STRIPE_TEST_KEY");
+            // using this temporarily while the main test account is deleting test data
+            var envKey = Environment.GetEnvironmentVariable("STRIPE_RECIPIENT_KEY");
+
+            //var envKey = Environment.GetEnvironmentVariable("STRIPE_TEST_KEY");
 
             StripeConfiguration.SetApiKey(envKey);
         }

--- a/src/Stripe.net.Tests/recipients/when_creating_a_recipient.cs
+++ b/src/Stripe.net.Tests/recipients/when_creating_a_recipient.cs
@@ -1,29 +1,29 @@
-﻿//using Machine.Specifications;
+﻿using Machine.Specifications;
 
-//namespace Stripe.Tests
-//{
-//    public class when_creating_a_recipient
-//    {
-//        protected static StripeRecipientCreateOptions StripeRecipientCreateOptions;
-//        protected static StripeRecipient StripeRecipient;
+namespace Stripe.Tests
+{
+    public class when_creating_a_recipient
+    {
+        protected static StripeRecipientCreateOptions StripeRecipientCreateOptions;
+        protected static StripeRecipient StripeRecipient;
 
-//        private static StripeRecipientService _stripeRecipientService;
+        private static StripeRecipientService _stripeRecipientService;
 
-//        Establish context = () =>
-//        {
-//            _stripeRecipientService = new StripeRecipientService();
-//            StripeRecipientCreateOptions = test_data.stripe_recipient_create_options.ValidIndividual();
-//        };
+        Establish context = () =>
+        {
+            _stripeRecipientService = new StripeRecipientService(Cache.RecipientApiKey);
+            StripeRecipientCreateOptions = test_data.stripe_recipient_create_options.ValidIndividual();
+        };
 
-//        Because of = () =>
-//            StripeRecipient = _stripeRecipientService.Create(StripeRecipientCreateOptions);
+        Because of = () =>
+            StripeRecipient = _stripeRecipientService.Create(StripeRecipientCreateOptions);
 
-//        Behaves_like<recipient_behaviors> behaviors;
+        Behaves_like<recipient_behaviors> behaviors;
 
-//        It should_have_metadata = () =>
-//            StripeRecipient.Metadata.Count.ShouldBeGreaterThan(0);
+        It should_have_metadata = () =>
+            StripeRecipient.Metadata.Count.ShouldBeGreaterThan(0);
 
-//        It should_have_correct_metadata = () =>
-//            StripeRecipient.Metadata.ShouldContainOnly(StripeRecipientCreateOptions.Metadata);
-//    }
-//}
+        It should_have_correct_metadata = () =>
+            StripeRecipient.Metadata.ShouldContainOnly(StripeRecipientCreateOptions.Metadata);
+    }
+}

--- a/src/Stripe.net.Tests/recipients/when_deleting_a_recipient.cs
+++ b/src/Stripe.net.Tests/recipients/when_deleting_a_recipient.cs
@@ -1,21 +1,21 @@
-﻿//using Machine.Specifications;
+﻿using Machine.Specifications;
 
-//namespace Stripe.Tests
-//{
-//    public class when_deleting_a_recipient
-//    {
-//        private static StripeRecipientService _stripeRecipientService;
-//        private static string _createdStripeRecipientId;
+namespace Stripe.Tests
+{
+    public class when_deleting_a_recipient
+    {
+        private static StripeRecipientService _stripeRecipientService;
+        private static string _createdStripeRecipientId;
 
-//        Establish context = () =>
-//        {
-//            _stripeRecipientService = new StripeRecipientService();
+        Establish context = () =>
+        {
+            _stripeRecipientService = new StripeRecipientService(Cache.RecipientApiKey);
 
-//            var stripeRecipient = _stripeRecipientService.Create(test_data.stripe_recipient_create_options.ValidIndividual());
-//            _createdStripeRecipientId = stripeRecipient.Id;
-//        };
+            var stripeRecipient = _stripeRecipientService.Create(test_data.stripe_recipient_create_options.ValidIndividual());
+            _createdStripeRecipientId = stripeRecipient.Id;
+        };
 
-//        Because of = () =>
-//            _stripeRecipientService.Delete(_createdStripeRecipientId);
-//    }
-//}
+        Because of = () =>
+            _stripeRecipientService.Delete(_createdStripeRecipientId);
+    }
+}

--- a/src/Stripe.net.Tests/recipients/when_getting_a_recipient.cs
+++ b/src/Stripe.net.Tests/recipients/when_getting_a_recipient.cs
@@ -1,56 +1,56 @@
-﻿//using Machine.Specifications;
+﻿using Machine.Specifications;
 
-//namespace Stripe.Tests
-//{
-//    public class when_getting_a_recipient
-//    {
-//        protected static StripeRecipientCreateOptions StripeRecipientCreateOptions;
-//        protected static StripeRecipient StripeRecipient;
+namespace Stripe.Tests
+{
+    public class when_getting_a_recipient
+    {
+        protected static StripeRecipientCreateOptions StripeRecipientCreateOptions;
+        protected static StripeRecipient StripeRecipient;
 
-//        private static StripeRecipientService _stripeRecipientService;
-//        private static string _createdStripeRecipientId;
+        private static StripeRecipientService _stripeRecipientService;
+        private static string _createdStripeRecipientId;
 
-//        Establish context = () =>
-//        {
-//            _stripeRecipientService = new StripeRecipientService();
-//            StripeRecipientCreateOptions = test_data.stripe_recipient_create_options.ValidCorporation();
+        Establish context = () =>
+        {
+            _stripeRecipientService = new StripeRecipientService(Cache.RecipientApiKey);
+            StripeRecipientCreateOptions = test_data.stripe_recipient_create_options.ValidCorporation();
 
-//            var stripeRecipient = _stripeRecipientService.Create(StripeRecipientCreateOptions);
-//            _createdStripeRecipientId = stripeRecipient.Id;
-//        };
+            var stripeRecipient = _stripeRecipientService.Create(StripeRecipientCreateOptions);
+            _createdStripeRecipientId = stripeRecipient.Id;
+        };
 
-//        Because of = () =>
-//        {
-//            StripeRecipient = _stripeRecipientService.Get(_createdStripeRecipientId);
-//        };
+        Because of = () =>
+        {
+            StripeRecipient = _stripeRecipientService.Get(_createdStripeRecipientId);
+        };
 
-//        Behaves_like<recipient_behaviors> behaviors;
+        Behaves_like<recipient_behaviors> behaviors;
 
-//        It should_have_active_account = () =>
-//            StripeRecipient.ActiveAccount.ShouldNotBeNull();
+        It should_have_active_account = () =>
+            StripeRecipient.ActiveAccount.ShouldNotBeNull();
 
-//        It should_have_active_account_routing_number = () =>
-//            StripeRecipient.ActiveAccount.RoutingNumber.ShouldEqual(StripeRecipientCreateOptions.BankAccount.RoutingNumber);
+        It should_have_active_account_routing_number = () =>
+            StripeRecipient.ActiveAccount.RoutingNumber.ShouldEqual(StripeRecipientCreateOptions.BankAccount.RoutingNumber);
 
-//        It should_have_active_account_country = () =>
-//            StripeRecipient.ActiveAccount.Country.ShouldEqual(StripeRecipientCreateOptions.BankAccount.Country);
+        It should_have_active_account_country = () =>
+            StripeRecipient.ActiveAccount.Country.ShouldEqual(StripeRecipientCreateOptions.BankAccount.Country);
 
-//        It should_have_active_account_currency = () =>
-//            StripeRecipient.ActiveAccount.Currency.ShouldEqual("usd");
+        It should_have_active_account_currency = () =>
+            StripeRecipient.ActiveAccount.Currency.ShouldEqual("usd");
 
-//        It should_have_default_for_currency = () =>
-//            StripeRecipient.ActiveAccount.DefaultForCurrency.ShouldBeFalse();
+        It should_have_default_for_currency = () =>
+            StripeRecipient.ActiveAccount.DefaultForCurrency.ShouldBeFalse();
 
-//        It should_have_active_account_last4 = () =>
-//            StripeRecipient.ActiveAccount.Last4.ShouldEqual("6789");
+        It should_have_active_account_last4 = () =>
+            StripeRecipient.ActiveAccount.Last4.ShouldEqual("6789");
 
-//        It should_have_active_account_status = () =>
-//            StripeRecipient.ActiveAccount.Status.ShouldNotBeEmpty();
+        It should_have_active_account_status = () =>
+            StripeRecipient.ActiveAccount.Status.ShouldNotBeEmpty();
 
-//        It should_have_active_account_bank_name = () =>
-//            StripeRecipient.ActiveAccount.BankName.ShouldNotBeEmpty();
+        It should_have_active_account_bank_name = () =>
+            StripeRecipient.ActiveAccount.BankName.ShouldNotBeEmpty();
 
-//        It should_have_active_account_fingerprint = () =>
-//            StripeRecipient.ActiveAccount.Fingerprint.ShouldNotBeEmpty();
-//    }
-//}
+        It should_have_active_account_fingerprint = () =>
+            StripeRecipient.ActiveAccount.Fingerprint.ShouldNotBeEmpty();
+    }
+}

--- a/src/Stripe.net.Tests/recipients/when_listing_recipients.cs
+++ b/src/Stripe.net.Tests/recipients/when_listing_recipients.cs
@@ -1,26 +1,26 @@
-﻿//using System.Collections.Generic;
-//using System.Linq;
-//using Machine.Specifications;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Machine.Specifications;
 
-//namespace Stripe.Tests
-//{
-//    public class when_listing_recipients
-//    {
-//        private static List<StripeRecipient> _stripeRecipientList;
-//        private static StripeRecipientService _stripeRecipientService;
+namespace Stripe.Tests
+{
+    public class when_listing_recipients
+    {
+        private static List<StripeRecipient> _stripeRecipientList;
+        private static StripeRecipientService _stripeRecipientService;
 
-//        Establish context = () =>
-//        {
-//            _stripeRecipientService = new StripeRecipientService();
+        Establish context = () =>
+        {
+            _stripeRecipientService = new StripeRecipientService(Cache.RecipientApiKey);
 
-//            _stripeRecipientService.Create(test_data.stripe_recipient_create_options.ValidCorporation());
-//            _stripeRecipientService.Create(test_data.stripe_recipient_create_options.ValidIndividual());
-//        };
+            _stripeRecipientService.Create(test_data.stripe_recipient_create_options.ValidCorporation());
+            _stripeRecipientService.Create(test_data.stripe_recipient_create_options.ValidIndividual());
+        };
 
-//        Because of = () =>
-//            _stripeRecipientList = _stripeRecipientService.List().ToList();
+        Because of = () =>
+            _stripeRecipientList = _stripeRecipientService.List().ToList();
 
-//        It should_havea_atleast_2_entries = () =>
-//            _stripeRecipientList.Count.ShouldBeGreaterThanOrEqualTo(2);
-//    }
-//}
+        It should_havea_atleast_2_entries = () =>
+            _stripeRecipientList.Count.ShouldBeGreaterThanOrEqualTo(2);
+    }
+}

--- a/src/Stripe.net.Tests/recipients/when_updating_a_recipient.cs
+++ b/src/Stripe.net.Tests/recipients/when_updating_a_recipient.cs
@@ -1,40 +1,40 @@
-﻿//using Machine.Specifications;
+﻿using Machine.Specifications;
 
-//namespace Stripe.Tests
-//{
-//    public class when_updating_a_recipient
-//    {
-//        private static StripeRecipient _stripeRecipient;
-//        private static StripeRecipientService _stripeRecipientService;
-//        private static string _createdStripeRecipientId;
-//        private static StripeRecipientUpdateOptions _stripeRecipientUpdateOptions;
+namespace Stripe.Tests
+{
+    public class when_updating_a_recipient
+    {
+        private static StripeRecipient _stripeRecipient;
+        private static StripeRecipientService _stripeRecipientService;
+        private static string _createdStripeRecipientId;
+        private static StripeRecipientUpdateOptions _stripeRecipientUpdateOptions;
 
-//        Establish context = () =>
-//        {
-//            _stripeRecipientService = new StripeRecipientService();
+        Establish context = () =>
+        {
+            _stripeRecipientService = new StripeRecipientService(Cache.RecipientApiKey);
 
-//            var stripeRecipient = _stripeRecipientService.Create(test_data.stripe_recipient_create_options.ValidIndividual());
-//            _createdStripeRecipientId = stripeRecipient.Id;
+            var stripeRecipient = _stripeRecipientService.Create(test_data.stripe_recipient_create_options.ValidIndividual());
+            _createdStripeRecipientId = stripeRecipient.Id;
 
-//            _stripeRecipientUpdateOptions = test_data.stripe_recipient_update_options.Valid();
-//        };
+            _stripeRecipientUpdateOptions = test_data.stripe_recipient_update_options.Valid();
+        };
 
-//        Because of = () =>
-//            _stripeRecipient = _stripeRecipientService.Update(_createdStripeRecipientId, _stripeRecipientUpdateOptions);
+        Because of = () =>
+            _stripeRecipient = _stripeRecipientService.Update(_createdStripeRecipientId, _stripeRecipientUpdateOptions);
 
-//        It should_have_the_correct_name = () =>
-//            _stripeRecipient.Name.ShouldEqual(_stripeRecipientUpdateOptions.Name);
+        It should_have_the_correct_name = () =>
+            _stripeRecipient.Name.ShouldEqual(_stripeRecipientUpdateOptions.Name);
 
-//        It should_have_the_correct_email = () =>
-//            _stripeRecipient.Email.ShouldEqual(_stripeRecipientUpdateOptions.Email);
+        It should_have_the_correct_email = () =>
+            _stripeRecipient.Email.ShouldEqual(_stripeRecipientUpdateOptions.Email);
 
-//        It should_have_the_correct_description = () =>
-//            _stripeRecipient.Description.ShouldEqual(_stripeRecipientUpdateOptions.Description);
+        It should_have_the_correct_description = () =>
+            _stripeRecipient.Description.ShouldEqual(_stripeRecipientUpdateOptions.Description);
 
-//        It should_have_metadata = () =>
-//            _stripeRecipient.Metadata.Count.ShouldBeGreaterThan(0);
+        It should_have_metadata = () =>
+            _stripeRecipient.Metadata.Count.ShouldBeGreaterThan(0);
 
-//        It should_have_correct_metadata = () =>
-//            _stripeRecipient.Metadata.ShouldContainOnly(_stripeRecipientUpdateOptions.Metadata);
-//    }
-//}
+        It should_have_correct_metadata = () =>
+            _stripeRecipient.Metadata.ShouldContainOnly(_stripeRecipientUpdateOptions.Metadata);
+    }
+}


### PR DESCRIPTION
* the recipient tests were added back, using the key **STRIPE_RECIPIENT_KEY** pointed to an account gated to use the feature (legacy only)