### PR TITLE
Invoice subscription items

### DIFF
--- a/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/InvoiceSubscriptionItemPlugin.cs
+++ b/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/InvoiceSubscriptionItemPlugin.cs
@@ -5,13 +5,13 @@ using Newtonsoft.Json;
 
 namespace Stripe.Infrastructure.Middleware
 {
-    internal class SubscriptionItemPlugin : IParserPlugin
+    internal class InvoiceSubscriptionItemPlugin : IParserPlugin
     {
         public bool Parse(ref string requestString, JsonPropertyAttribute attribute, PropertyInfo property, object propertyValue, object propertyParent)
         {
-            if (attribute.PropertyName != "subscription_items_array") return false;
+            if (attribute.PropertyName != "subscription_items_array_invoice") return false;
 
-            var items = ((List<StripeSubscriptionItemOption>) property.GetValue(propertyParent, null));
+            var items = ((List<StripeInvoiceSubscriptionItemOptions>) property.GetValue(propertyParent, null));
 
             var itemIndex = 0;
             foreach (var item in items)
@@ -28,7 +28,7 @@ namespace Stripe.Infrastructure.Middleware
                     if (attr == null) continue;
 
                     RequestStringBuilder.ApplyParameterToRequestString(ref requestString,
-                        $"items[{itemIndex}][{attr.PropertyName}]", value.ToString());
+                        $"subscription_items[{itemIndex}][{attr.PropertyName}]", value.ToString());
                 }
 
                 itemIndex++;

--- a/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/SubscriptionItemUpdatedPlugin.cs
+++ b/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/SubscriptionItemUpdatedPlugin.cs
@@ -10,7 +10,7 @@ namespace Stripe.Infrastructure.Middleware
     {
         public bool Parse(ref string requestString, JsonPropertyAttribute attribute, PropertyInfo property, object propertyValue, object propertyParent)
         {
-            if (attribute.PropertyName != "subscription_items_updated") return false;
+            if (attribute.PropertyName != "subscription_items_array_updated") return false;
 
             var items = ((List<StripeSubscriptionItemUpdateOption>) property.GetValue(propertyParent, null));
 

--- a/src/Stripe.net/Infrastructure/Middleware/RequestStringBuilder.cs
+++ b/src/Stripe.net/Infrastructure/Middleware/RequestStringBuilder.cs
@@ -22,7 +22,8 @@ namespace Stripe.Infrastructure.Middleware
                 new DictionaryPlugin(),
                 new IncludePlugin(),
                 new SubscriptionItemPlugin(),
-                new SubscriptionItemUpdatedPlugin()
+                new SubscriptionItemUpdatedPlugin(),
+                new InvoiceSubscriptionItemPlugin()
             };
         }
 

--- a/src/Stripe.net/Services/Invoices/StripeInvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeInvoiceListLineItemsOptions.cs
@@ -17,6 +17,8 @@ namespace Stripe
         [JsonProperty("subscription_plan")]
         public string SubscriptionPlanId { get; set; }
 
+        // this will actually send subscription_items. this is to flag it for the middleware
+        // to process it as a plugin
         [JsonProperty("subscription_items_array_invoice")]
         public List<StripeInvoiceSubscriptionItemOptions> SubscriptionItems { get; set; }
     }

--- a/src/Stripe.net/Services/Invoices/StripeInvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeInvoiceListLineItemsOptions.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Stripe
 {
@@ -15,5 +16,8 @@ namespace Stripe
 
         [JsonProperty("subscription_plan")]
         public string SubscriptionPlanId { get; set; }
+
+        [JsonProperty("subscription_items_array_invoice")]
+        public List<StripeInvoiceSubscriptionItemOptions> SubscriptionItems { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Invoices/StripeInvoiceSubscriptionItemOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeInvoiceSubscriptionItemOptions.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeInvoiceSubscriptionItemOptions
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("deleted")]
+        public bool? Deleted { get; set; }
+
+        [JsonProperty("plan")]
+        public string PlanId { get; set; }
+
+        [JsonProperty("quantity")]
+        public int? Quantity { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
@@ -50,6 +50,8 @@ namespace Stripe
             }
         }
 
+        // this will actually send subscription_items. this is to flag it for the middleware
+        // to process it as a plugin
         [JsonProperty("subscription_items_array_invoice")]
         public List<StripeInvoiceSubscriptionItemOptions> SubscriptionItems { get; set; }
     }

--- a/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Newtonsoft.Json;
 using Stripe.Infrastructure;
+using System.Collections.Generic;
 
 namespace Stripe
 {
@@ -48,5 +49,8 @@ namespace Stripe
                 return EpochTime.ConvertDateTimeToEpoch(SubscriptionTrialEnd.Value);
             }
         }
+
+        [JsonProperty("subscription_items_array_invoice")]
+        public List<StripeInvoiceSubscriptionItemOptions> SubscriptionItems { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionCreateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionCreateOptions.cs
@@ -28,7 +28,7 @@ namespace Stripe
 
         // this will actually send items. this is to flag it for the middleware
         // to process it as a plugin
-        [JsonProperty("subscription_items")]
+        [JsonProperty("subscription_items_array")]
         public List<StripeSubscriptionItemOption> Items { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionUpdateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionUpdateOptions.cs
@@ -17,7 +17,7 @@ namespace Stripe
 
         // this will actually send items. this is to flag it for the middleware
         // to process it as a plugin
-        [JsonProperty("subscription_items_updated")]
+        [JsonProperty("subscription_items_array_updated")]
         public List<StripeSubscriptionItemUpdateOption> Items { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds support for the missing `subscription_items` parameters for https://stripe.com/docs/api#invoice_lines and https://stripe.com/docs/api#upcoming_invoice .

You can see it's implementation in action here: https://github.com/bitwarden/core/commit/fa565f46c61a9464b51384a2397d4672afb60531#diff-6e37b3164a3aea7da3eb22f74e3b4f9dR400

Note that I changed the `subscription_items*` keywords to `subscription_items_array*` in the middleware plugins as to not be confused with properties that are identified in the actual API spec as `subscription_items`. If you prefer some other approach here let me know.

Also, note that I did not add any tests for this new functionality. Feel free to fill in any gaps you would like covered for test cases. I did, however, test this with my implementation linked above and it works.