### PR TITLE
Make build settings work on Mac with the dotnet command line tool

### DIFF
--- a/src/Stripe.Tests.XUnit/Stripe.Tests.XUnit.csproj
+++ b/src/Stripe.Tests.XUnit/Stripe.Tests.XUnit.csproj
@@ -8,7 +8,7 @@
     <RuntimeIdentifiers>win10-x64;win81-x64;osx.10.12-x64</RuntimeIdentifiers>
     <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>1.2</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stripe.net.Tests/Stripe.net.Tests.csproj
+++ b/src/Stripe.net.Tests/Stripe.net.Tests.csproj
@@ -2,11 +2,12 @@
 
   <PropertyGroup>
     <VersionPrefix>0.0.0</VersionPrefix>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <AssemblyName>Stripe.net.Tests</AssemblyName>
     <PackageId>Stripe.net.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
+    <NetStandardImplicitPackageVersion>1.2</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,7 +21,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <EmbeddedResource Include="fileuploads\test_data\logo.png" />
     <EmbeddedResource Include="infrastructure\test_data\card.json" />
     <EmbeddedResource Include="infrastructure\test_data\charge.json" />
@@ -29,24 +30,6 @@
     <EmbeddedResource Include="infrastructure\test_data\invoice.json" />
     <EmbeddedResource Include="infrastructure\test_data\invoice_item.json" />
     <EmbeddedResource Include="infrastructure\test_data\subscription.json" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Collections" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.Remoting" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Serialization" />
-    <Reference Include="System" />
   </ItemGroup>
 
 </Project>

--- a/src/Stripe.net.Tests/infrastructure/when_building_the_client.cs
+++ b/src/Stripe.net.Tests/infrastructure/when_building_the_client.cs
@@ -34,10 +34,10 @@ namespace Stripe.Tests
             var clientData = JToken.Parse(request.Headers.GetValues("X-Stripe-Client-User-Agent").FirstOrDefault());
         };
 
-        It should_have_the_net45_for_uname = () =>
+        It should_have_the_platform_in_the_uname = () =>
         {
             var clientData = JToken.Parse(request.Headers.GetValues("X-Stripe-Client-User-Agent").FirstOrDefault());
-            clientData.SelectToken("uname").ToString().ShouldContain("net45.");
+            clientData.SelectToken("uname").ToString().ShouldContain(".platform");
         };
     }
 }


### PR DESCRIPTION
This involves changing the target to netcoreapp1.1 & including an implicit NetStandard
version in each test project's build settings.

cc @andrewnelder