### PR TITLE
[WIP] Support API version 2017-05-25

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,15 +125,15 @@ Accounts
 --------
 ### Creating an account
 
-When creating an account, you can create a standalone or managed account. Standalone accounts are managed by Stripe and the account owner directly. Managed accounts are handled by your platform. See the Stripe documentation for more information.
+When creating an account, you can create a Standard or Custom account. Standard accounts are managed by Stripe and the account owner directly. Custom accounts are handled by your platform. See the Stripe documentation for more information.
 
 Since Stripe returns `ExternalAccounts` as a single array (contains StripeCard's and/or StripeBankAccount's), that type is a dynamic StripeList. These are split up as `ExternalCards` and `ExternalBankAccounts` for your convenience.
 
 ```csharp
 	var account = new StripeAccountCreateOptions();
-	account.Email = "jayme@yoyoyo.com"  // this is required if it is not a managed account. the user is emailed on standalone accounts,
-	                                    // it's only used for reference on managed accounts
-	account.Managed = false;            // set this to true if you want a managed account (email is not required if this is set to true)
+	account.Email = "jayme@yoyoyo.com"  // this is required for a Standard account as the owner gets emails from Stripe.
+	                                    // it's only used for reference on Custom accounts
+	account.Type = "custom";            // this can be "custom" or "standard". Express accounts are not created via the API.
 
 	// a few optional settings
 	account.Country = "US"                                 // defaults to your country

--- a/src/Stripe.Tests.XUnit/accounts/_cache.cs
+++ b/src/Stripe.Tests.XUnit/accounts/_cache.cs
@@ -20,7 +20,7 @@ namespace Stripe.Tests.Xunit
                 DeclineChargeOnAvsFailure = false,
                 DeclineChargeOnCvcFailure = true,
                 DefaultCurrency = "usd",
-                Managed = true,
+                Type = "custom",
 
                 ExternalBankAccount = new StripeAccountBankAccountOptions()
                 {

--- a/src/Stripe.Tests.XUnit/accounts/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/accounts/_fixture.cs
@@ -31,7 +31,7 @@ namespace Stripe.Tests.Xunit
                 DeclineChargeOnCvcFailure = true,
                 DefaultCurrency = "usd",
                 Email = "caesar@turing.dpn",
-                Managed = true,
+                Type = "custom",
                 ExternalCardAccount = new StripeAccountCardOptions()
                 {
                     AddressCountry = "US",

--- a/src/Stripe.Tests.XUnit/accounts/when_creating_additional_owners_empty_list.cs
+++ b/src/Stripe.Tests.XUnit/accounts/when_creating_additional_owners_empty_list.cs
@@ -14,7 +14,7 @@ namespace Stripe.Tests.Xunit
                 new StripeAccountCreateOptions
                 {
                     Email = "happy@gilmore.com",
-                    Managed = true,
+                    Type = "custom",
                     LegalEntity = new StripeAccountLegalEntityOptions
                     {
                         AdditionalOwners = new List<StripeAccountAdditionalOwner>()

--- a/src/Stripe.Tests.XUnit/connect/when_charging_from_managed_account.cs
+++ b/src/Stripe.Tests.XUnit/connect/when_charging_from_managed_account.cs
@@ -14,7 +14,7 @@ namespace Stripe.Tests.Xunit
                 {
                     DefaultCurrency = "usd",
                     Email = "cu_xxxxxx@gmail.com",
-                    Managed = true
+                    Type = "custom"
                 }
             );
 

--- a/src/Stripe.Tests.XUnit/errors/when_deleting_an_account.cs
+++ b/src/Stripe.Tests.XUnit/errors/when_deleting_an_account.cs
@@ -16,7 +16,7 @@ namespace Stripe.Tests.Xunit
             _stripeAccountCreateOptions = new StripeAccountCreateOptions()
             {
                 Email = "joe@" + Guid.NewGuid() + ".com",
-                Managed = true
+                Type = "custom"
             };
             _stripeAccountId = _stripeAccountService.Create(_stripeAccountCreateOptions).Id;
 

--- a/src/Stripe.Tests.XUnit/events/event.json
+++ b/src/Stripe.Tests.XUnit/events/event.json
@@ -1,7 +1,8 @@
 ﻿{
   "id": "evt_1ADKLLLWlyqCpbLp0qRyqExL",
   "object": "event",
-  "api_version": "2017-04-06",
+  "account": "acct_CONNECT",
+  "api_version": "2017-05-25",
   "created": 1493329207,
   "data": {
     "object": {
@@ -34,6 +35,9 @@
   },
   "livemode": false,
   "pending_webhooks": 2,
-  "request": null,
+  "request": {
+    "id": "req_FAKE",
+    "idempotency_key": "placeholder"
+  },
   "type": "invoiceitem.updated"
 }

--- a/src/Stripe.Tests.XUnit/events/when_constructing_an_event.cs
+++ b/src/Stripe.Tests.XUnit/events/when_constructing_an_event.cs
@@ -9,7 +9,7 @@ namespace Stripe.Tests.Xunit
     public class when_constructing_an_event
     {
         // this was sent in the header Stripe-Signature along with the body of event.json in a test webhook
-        private static string StripeSignature => "t=1493329224,v1=09b8e30b483570b410390cdac6327c036937e84a6316008a0143db833ac21a09,v0=63f3a72374a733066c4be69ed7f8e5ac85c22c9f0a6a612ab9a025a9e4ee7eef";
+        private static string StripeSignature => "t=1493329224,v1=dca14f723dfa3bf47a310c3d6c3aff8bdb2534263d051dd2613ece097b8bdea4,v0=63f3a72374a733066c4be69ed7f8e5ac85c22c9f0a6a612ab9a025a9e4ee7eef";
         private static string StripeJson { get; set; }
         private static string StripeSecret => "whsec_H68eTX02a4bCbiQOOoSAsIytOvuWZrQC";
 
@@ -38,6 +38,9 @@ namespace Stripe.Tests.Xunit
         public void it_should_validate_with_right_data()
         {
             ConstructedEvent.Should().NotBeNull();
+            Assert.True(ConstructedEvent.Request.Id.Equals("req_FAKE"));
+            Assert.True(ConstructedEvent.Request.IdempotencyKey.Equals("placeholder"));
+            Assert.True(ConstructedEvent.Account.Equals("acct_CONNECT"));
         }
     }
 }

--- a/src/Stripe.net.Tests/Cache.cs
+++ b/src/Stripe.net.Tests/Cache.cs
@@ -8,41 +8,41 @@ namespace Stripe.Tests
         public static string RecipientApiKey => Environment.GetEnvironmentVariable("STRIPE_RECIPIENT_KEY");
 
 
-        public static StripeAccountCreateOptions ManagedAccountWithCardOptions { get; set; }
-        public static StripeAccountCreateOptions ManagedAccountWithBankAccountOptions { get; set; }
+        public static StripeAccountCreateOptions CustomAccountWithCardOptions { get; set; }
+        public static StripeAccountCreateOptions CustomAccountWithBankAccountOptions { get; set; }
 
-        private static StripeAccount _managedAccountWithCard { get; set; }
-        private static StripeAccount _managedAccountWithBankAccount { get; set; }
+        private static StripeAccount _customAccountWithCard { get; set; }
+        private static StripeAccount _customAccountWithBankAccount { get; set; }
 
-        public static StripeAccount GetManagedAccountWithCard()
+        public static StripeAccount GetCustomAccountWithCard()
         {  
-            if(_managedAccountWithCard != null) return _managedAccountWithCard;
+            if(_customAccountWithCard != null) return _customAccountWithCard;
 
             var options = test_data.stripe_account_create_options.ValidAccountWithCard();
             options.Country = "US";
             options.Email = $"joe{ Guid.NewGuid() }@blahblah.com";
-            options.Managed = true;
+            options.Type = "custom";
             options.TosAcceptanceDate = DateTime.UtcNow.Date;
             options.TosAcceptanceIp = "8.8.8.8";
             options.TosAcceptanceUserAgent = "user-agent-7";
 
-            ManagedAccountWithCardOptions = options;
+            CustomAccountWithCardOptions = options;
 
-            return _managedAccountWithCard = new StripeAccountService().Create(options);
+            return _customAccountWithCard = new StripeAccountService().Create(options);
         }
 
-        public static StripeAccount GetManagedAccountWithBankAccount()
+        public static StripeAccount GetCustomAccountWithBankAccount()
         {
-            if (_managedAccountWithBankAccount != null) return _managedAccountWithBankAccount;
+            if (_customAccountWithBankAccount != null) return _customAccountWithBankAccount;
 
             var options = test_data.stripe_account_create_options.ValidAccountWithBankAccount();
             options.Country = "US";
             options.Email = $"joe{ Guid.NewGuid() }@blahblah.com";
-            options.Managed = true;
+            options.Type = "custom";
 
-            ManagedAccountWithBankAccountOptions = options;
+            CustomAccountWithBankAccountOptions = options;
 
-            return _managedAccountWithBankAccount = new StripeAccountService().Create(options);
+            return _customAccountWithBankAccount = new StripeAccountService().Create(options);
         }
 
     }

--- a/src/Stripe.net.Tests/account/test_data/stripe_account_create_options.cs
+++ b/src/Stripe.net.Tests/account/test_data/stripe_account_create_options.cs
@@ -17,7 +17,7 @@ namespace Stripe.Tests.test_data
                 DeclineChargeOnCvcFailure = true,
                 DefaultCurrency = "usd",
                 Email = $"Debra{Guid.NewGuid()}@gmail.com",
-                Managed = true,
+                Type = "custom",
 
                 ExternalCardAccount = new StripeAccountCardOptions()
                 {
@@ -49,7 +49,7 @@ namespace Stripe.Tests.test_data
                 DeclineChargeOnAvsFailure = false,
                 DeclineChargeOnCvcFailure = true,
                 DefaultCurrency = "usd",
-                Managed = true,
+                Type = "custom",
 
                 ExternalBankAccount = new StripeAccountBankAccountOptions()
                 {

--- a/src/Stripe.net.Tests/account/when_creating_a_managed_account_with_a_bank_account.cs
+++ b/src/Stripe.net.Tests/account/when_creating_a_managed_account_with_a_bank_account.cs
@@ -4,7 +4,7 @@ using Machine.Specifications;
 
 namespace Stripe.Tests
 {
-    public class when_creating_a_managed_account_with_a_bank_account
+    public class when_creating_a_custom_account_with_a_bank_account
     {
         protected static StripeAccountCreateOptions CreateOrUpdateOptions;
         protected static StripeAccount StripeAccount;
@@ -15,12 +15,12 @@ namespace Stripe.Tests
         {
             _stripeAccountService = new StripeAccountService();
 
-            Cache.GetManagedAccountWithBankAccount();
-            CreateOrUpdateOptions = Cache.ManagedAccountWithBankAccountOptions;
+            Cache.GetCustomAccountWithBankAccount();
+            CreateOrUpdateOptions = Cache.CustomAccountWithBankAccountOptions;
         };
 
         Because of = () =>
-            StripeAccount = Cache.GetManagedAccountWithBankAccount();
+            StripeAccount = Cache.GetCustomAccountWithBankAccount();
 
         It should_have_the_correct_country = () =>
             StripeAccount.Country.ShouldEqual(CreateOrUpdateOptions.Country);
@@ -28,8 +28,8 @@ namespace Stripe.Tests
         It should_have_the_correct_email = () =>
             StripeAccount.Email.ShouldEqual(CreateOrUpdateOptions.Email);
 
-        It should_be_a_managed_account = () =>
-            StripeAccount.Managed.ShouldEqual(true);
+        It should_be_a_custom_account = () =>
+            StripeAccount.Type.ShouldEqual("custom");
 
         It should_have_the_correct_external_account_info = () =>
         {

--- a/src/Stripe.net.Tests/account/when_creating_a_managed_account_with_a_card.cs
+++ b/src/Stripe.net.Tests/account/when_creating_a_managed_account_with_a_card.cs
@@ -4,7 +4,7 @@ using Machine.Specifications;
 
 namespace Stripe.Tests
 {
-    public class when_creating_a_managed_account_with_a_card
+    public class when_creating_a_custom_account_with_a_card
     {
         protected static StripeAccountCreateOptions CreateOrUpdateOptions;
         protected static StripeAccount StripeAccount;
@@ -18,8 +18,8 @@ namespace Stripe.Tests
 
         Because of = () =>
         {
-            StripeAccount = Cache.GetManagedAccountWithCard();
-            CreateOrUpdateOptions = Cache.ManagedAccountWithCardOptions;
+            StripeAccount = Cache.GetCustomAccountWithCard();
+            CreateOrUpdateOptions = Cache.CustomAccountWithCardOptions;
         };
 
         It should_have_the_correct_country = () =>
@@ -28,8 +28,8 @@ namespace Stripe.Tests
         It should_have_the_correct_email = () =>
             StripeAccount.Email.ShouldEqual(CreateOrUpdateOptions.Email);
 
-        It should_be_a_managed_account = () =>
-            StripeAccount.Managed.ShouldEqual(true);
+        It should_be_a_custom_account = () =>
+            StripeAccount.Type.ShouldEqual("custom");
 
         It should_have_the_correct_external_account_info = () =>
         {

--- a/src/Stripe.net.Tests/account/when_creating_an_account_with_a_legal_entity.cs
+++ b/src/Stripe.net.Tests/account/when_creating_an_account_with_a_legal_entity.cs
@@ -16,7 +16,7 @@ namespace Stripe.Tests
             _stripeAccountCreateOptions = new StripeAccountCreateOptions()
             {
                 Email = "joe@" + Guid.NewGuid() + ".com",
-                Managed = true
+                Type = "custom"
             };
 
             _timestamp = DateTime.UtcNow.Date;

--- a/src/Stripe.net.Tests/account/when_creating_an_account_with_tos_acceptance.cs
+++ b/src/Stripe.net.Tests/account/when_creating_an_account_with_tos_acceptance.cs
@@ -10,12 +10,12 @@ namespace Stripe.Tests
 
         Establish context = () =>
         {
-            _stripeAccount = Cache.GetManagedAccountWithCard();
-            _stripeAccountCreateOptions = Cache.ManagedAccountWithCardOptions;
+            _stripeAccount = Cache.GetCustomAccountWithCard();
+            _stripeAccountCreateOptions = Cache.CustomAccountWithCardOptions;
         };
 
         Because of = () =>
-            _stripeAccount = Cache.GetManagedAccountWithCard();
+            _stripeAccount = Cache.GetCustomAccountWithCard();
 
         It should_have_the_correct_email_address = () =>
             _stripeAccount.Email.ShouldEqual(_stripeAccountCreateOptions.Email);

--- a/src/Stripe.net.Tests/account/when_deleting_an_account.cs
+++ b/src/Stripe.net.Tests/account/when_deleting_an_account.cs
@@ -16,7 +16,7 @@ namespace Stripe.Tests
             _stripeAccountCreateOptions = new StripeAccountCreateOptions()
             {
                 Email = "joe@" + Guid.NewGuid() + ".com",
-                Managed = true
+                Type = "custom"
             };
             _stripeAccountId = _stripeAccountService.Create(_stripeAccountCreateOptions).Id;
         };

--- a/src/Stripe.net.Tests/account/when_retrieving_an_account.cs
+++ b/src/Stripe.net.Tests/account/when_retrieving_an_account.cs
@@ -12,7 +12,7 @@ namespace Stripe.Tests
         {
             _stripeAccountService = new StripeAccountService();
 
-            _createdAccount = Cache.GetManagedAccountWithCard();
+            _createdAccount = Cache.GetCustomAccountWithCard();
         };
 
         Because of = () =>

--- a/src/Stripe.net.Tests/account/when_updating_an_account.cs
+++ b/src/Stripe.net.Tests/account/when_updating_an_account.cs
@@ -18,7 +18,7 @@ namespace Stripe.Tests
             _stripeAccountCreateOptions = test_data.stripe_account_create_options.ValidAccountWithCard();
             _stripeAccountCreateOptions.Country = "US";
             _stripeAccountCreateOptions.Email = "joe" + Guid.NewGuid() + "@blahblah.com";
-            _stripeAccountCreateOptions.Managed = true;
+            _stripeAccountCreateOptions.Type = "custom";
 
             _stripeBankAccountOptions = test_data.stripe_account_create_options.ValidAccountWithBankAccount().ExternalBankAccount;
 

--- a/src/Stripe.net.Tests/account/when_updating_an_account_with_a_bank_account_token.cs
+++ b/src/Stripe.net.Tests/account/when_updating_an_account_with_a_bank_account_token.cs
@@ -17,7 +17,7 @@ namespace Stripe.Tests
             var stripeAccountCreateOptions = test_data.stripe_account_create_options.ValidAccountWithBankAccount();
             stripeAccountCreateOptions.Country = "US";
             stripeAccountCreateOptions.Email = "joe" + Guid.NewGuid() + "@blahblah.com";
-            stripeAccountCreateOptions.Managed = true;
+            stripeAccountCreateOptions.Type = "custom";
 
             _initialAccount = _stripeAccountService.Create(stripeAccountCreateOptions);
 

--- a/src/Stripe.net.Tests/account/when_updating_an_account_with_a_card_token.cs
+++ b/src/Stripe.net.Tests/account/when_updating_an_account_with_a_card_token.cs
@@ -14,10 +14,10 @@ namespace Stripe.Tests
 
         Establish context = () =>
         {
-            // create a managed account
+            // create a custom account
             _stripeAccountService = new StripeAccountService();
 
-            _initialAccount = Cache.GetManagedAccountWithCard();
+            _initialAccount = Cache.GetCustomAccountWithCard();
 
             // create a token for a new card
             var tokenOptions = test_data.stripe_token_create_options.ValidDebitCard();

--- a/src/Stripe.net.Tests/applicationfeerefunds/when_creating_an_application_fee_refund.cs
+++ b/src/Stripe.net.Tests/applicationfeerefunds/when_creating_an_application_fee_refund.cs
@@ -9,18 +9,18 @@ namespace Stripe.Tests
 
         Establish context = () =>
         {
-            var managedAccount = Cache.GetManagedAccountWithCard();
+            var customAccount = Cache.GetCustomAccountWithCard();
 
             var token = new StripeTokenService().Create(test_data.stripe_token_create_options.Valid());
 
-            // create a charge on that managed account with an application fee of 10 cents
+            // create a charge on that custom account with an application fee of 10 cents
             var chargeCreateOptions = test_data.stripe_charge_create_options.ValidToken(token.Id);
             chargeCreateOptions.ApplicationFee = 10;
 
             _charge = new StripeChargeService().Create(chargeCreateOptions, 
                 new StripeRequestOptions
                 {
-                    StripeConnectAccountId = managedAccount.Id
+                    StripeConnectAccountId = customAccount.Id
                 }
             );
         };

--- a/src/Stripe.net.Tests/applicationfeerefunds/when_creating_an_application_fee_refund_async.cs
+++ b/src/Stripe.net.Tests/applicationfeerefunds/when_creating_an_application_fee_refund_async.cs
@@ -9,18 +9,18 @@ namespace Stripe.Tests
 
         Establish context = () =>
         {
-            var managedAccount = Cache.GetManagedAccountWithCard();
+            var customAccount = Cache.GetCustomAccountWithCard();
 
             var token = new StripeTokenService().Create(test_data.stripe_token_create_options.Valid());
 
-            // create a charge on that managed account with an application fee of 10 cents
+            // create a charge on that custom account with an application fee of 10 cents
             var chargeCreateOptions = test_data.stripe_charge_create_options.ValidToken(token.Id);
             chargeCreateOptions.ApplicationFee = 10;
 
             _charge = new StripeChargeService().Create(chargeCreateOptions, 
                 new StripeRequestOptions
                 {
-                    StripeConnectAccountId = managedAccount.Id
+                    StripeConnectAccountId = customAccount.Id
                 }
             );
         };

--- a/src/Stripe.net.Tests/applicationfeerefunds/when_getting_an_application_fee_refund.cs
+++ b/src/Stripe.net.Tests/applicationfeerefunds/when_getting_an_application_fee_refund.cs
@@ -10,18 +10,18 @@ namespace Stripe.Tests
 
         Establish context = () =>
         {
-            var managedAccount = Cache.GetManagedAccountWithCard();
+            var customAccount = Cache.GetCustomAccountWithCard();
 
             var token = new StripeTokenService().Create(test_data.stripe_token_create_options.Valid());
 
-            // create a charge on that managed account with an application fee of 10 cents
+            // create a charge on that custom account with an application fee of 10 cents
             var chargeCreateOptions = test_data.stripe_charge_create_options.ValidToken(token.Id);
             chargeCreateOptions.ApplicationFee = 10;
 
             _charge = new StripeChargeService().Create(chargeCreateOptions,
                 new StripeRequestOptions
                 {
-                    StripeConnectAccountId = managedAccount.Id
+                    StripeConnectAccountId = customAccount.Id
                 }
             );
 

--- a/src/Stripe.net.Tests/applicationfeerefunds/when_getting_an_application_fee_refund_async.cs
+++ b/src/Stripe.net.Tests/applicationfeerefunds/when_getting_an_application_fee_refund_async.cs
@@ -10,18 +10,18 @@ namespace Stripe.Tests
 
         Establish context = () =>
         {
-            var managedAccount = Cache.GetManagedAccountWithCard();
+            var customAccount = Cache.GetCustomAccountWithCard();
 
             var token = new StripeTokenService().Create(test_data.stripe_token_create_options.Valid());
 
-            // create a charge on that managed account with an application fee of 10 cents
+            // create a charge on that custom account with an application fee of 10 cents
             var chargeCreateOptions = test_data.stripe_charge_create_options.ValidToken(token.Id);
             chargeCreateOptions.ApplicationFee = 10;
 
             _charge = new StripeChargeService().Create(chargeCreateOptions,
                 new StripeRequestOptions
                 {
-                    StripeConnectAccountId = managedAccount.Id
+                    StripeConnectAccountId = customAccount.Id
                 }
             );
 

--- a/src/Stripe.net.Tests/applicationfeerefunds/when_listing_application_fee_refunds.cs
+++ b/src/Stripe.net.Tests/applicationfeerefunds/when_listing_application_fee_refunds.cs
@@ -13,18 +13,18 @@ namespace Stripe.Tests
 
         Establish context = () =>
         {
-            var managedAccount = Cache.GetManagedAccountWithCard();
+            var customAccount = Cache.GetCustomAccountWithCard();
 
             var token = new StripeTokenService().Create(test_data.stripe_token_create_options.Valid());
 
-            // create a charge on that managed account with an application fee of 10 cents
+            // create a charge on that custom account with an application fee of 10 cents
             var chargeCreateOptions = test_data.stripe_charge_create_options.ValidToken(token.Id);
             chargeCreateOptions.ApplicationFee = 20;
 
             _charge = new StripeChargeService().Create(chargeCreateOptions,
                 new StripeRequestOptions
                 {
-                    StripeConnectAccountId = managedAccount.Id
+                    StripeConnectAccountId = customAccount.Id
                 }
             );
 

--- a/src/Stripe.net.Tests/applicationfeerefunds/when_updating_an_application_fee_refund.cs
+++ b/src/Stripe.net.Tests/applicationfeerefunds/when_updating_an_application_fee_refund.cs
@@ -17,18 +17,18 @@ namespace Stripe.Tests
 
         Establish context = () =>
         {
-            var managedAccount = Cache.GetManagedAccountWithCard();
+            var customAccount = Cache.GetCustomAccountWithCard();
 
             var token = new StripeTokenService().Create(test_data.stripe_token_create_options.Valid());
 
-            // create a charge on that managed account with an application fee of 10 cents
+            // create a charge on that custom account with an application fee of 10 cents
             var chargeCreateOptions = test_data.stripe_charge_create_options.ValidToken(token.Id);
             chargeCreateOptions.ApplicationFee = 10;
 
             _charge = new StripeChargeService().Create(chargeCreateOptions,
                 new StripeRequestOptions
                 {
-                    StripeConnectAccountId = managedAccount.Id
+                    StripeConnectAccountId = customAccount.Id
                 }
             );
 

--- a/src/Stripe.net.Tests/applicationfeerefunds/when_updating_an_application_fee_refund_async.cs
+++ b/src/Stripe.net.Tests/applicationfeerefunds/when_updating_an_application_fee_refund_async.cs
@@ -17,7 +17,7 @@ namespace Stripe.Tests
 
         Establish context = () =>
         {
-            var managedAccount = Cache.GetManagedAccountWithCard();
+            var customAccount = Cache.GetCustomAccountWithCard();
 
             var token = new StripeTokenService().Create(test_data.stripe_token_create_options.Valid());
 
@@ -27,7 +27,7 @@ namespace Stripe.Tests
             _charge = new StripeChargeService().Create(chargeCreateOptions,
                 new StripeRequestOptions
                 {
-                    StripeConnectAccountId = managedAccount.Id
+                    StripeConnectAccountId = customAccount.Id
                 }
             );
 

--- a/src/Stripe.net.Tests/charges/when_creating_a_charge_on_a_connected_account.cs
+++ b/src/Stripe.net.Tests/charges/when_creating_a_charge_on_a_connected_account.cs
@@ -13,8 +13,8 @@ namespace Stripe.Tests
 
         Establish context = () =>
         {
-            // setup a managed (connect) account
-            _account = Cache.GetManagedAccountWithCard();
+            // setup a custom (connect) account
+            _account = Cache.GetCustomAccountWithCard();
 
             // create a token (not on the connected account)
             _token = new StripeTokenService().Create(test_data.stripe_token_create_options.Valid());
@@ -25,7 +25,7 @@ namespace Stripe.Tests
 
         Because of = () =>
         {
-            // create a charge using a token with the destination set to the managed account
+            // create a charge using a token with the destination set to the custom account
             _charge = _chargeService
                 .Create(test_data.stripe_charge_create_options.ValidTokenWithDestination(_token.Id, _account.Id, 100));
         };

--- a/src/Stripe.net/Entities/StripeAccount.cs
+++ b/src/Stripe.net/Entities/StripeAccount.cs
@@ -55,9 +55,6 @@ namespace Stripe
         [JsonProperty("legal_entity")]
         public StripeLegalEntity LegalEntity { get; set; }
 
-        [JsonProperty("managed")]
-        public bool Managed { get; set; }
-
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
@@ -82,6 +79,9 @@ namespace Stripe
         [JsonProperty("tos_acceptance")]
         public StripeTermsOfServiceAcceptance TermsOfServiceAcceptance { get; set; }
 
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
         [JsonProperty("payouts_enabled")]
         public bool PayoutsEnabled { get; set; }
 
@@ -95,6 +95,6 @@ namespace Stripe
         public StripeAccountVerification AccountVerification { get; set; }
 
         [JsonProperty("keys")]
-        public StripeManagedAccountKeys ManagedAccountKeys { get; set; }
+        public StripeCustomAccountKeys CustomAccountKeys { get; set; }
      }
 }

--- a/src/Stripe.net/Entities/StripeEvent.cs
+++ b/src/Stripe.net/Entities/StripeEvent.cs
@@ -9,6 +9,9 @@ namespace Stripe
         [JsonProperty("type")]
         public string Type { get; set; }
 
+        [JsonProperty("account")]
+        public string Account { get; set; }
+
         [JsonProperty("created")]
         [JsonConverter(typeof(StripeDateTimeConverter))]
         public DateTime? Created { get; set; }
@@ -19,13 +22,10 @@ namespace Stripe
         [JsonProperty("livemode")]
         public bool LiveMode { get; set; }
 
-        [JsonProperty("user_id")]
-        public string UserId { get; set; }
-
         [JsonProperty("pending_webhooks")]
         public int PendingWebhooks { get; set; }
 
         [JsonProperty("request")]
-        public string Request { get; set; }
+        public StripeEventRequest Request { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeEventRequest.cs
+++ b/src/Stripe.net/Entities/StripeEventRequest.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+	public class StripeEventRequest : StripeEntity
+	{
+		[JsonProperty("id")]
+		public string Id { get; set; }
+
+		[JsonProperty("idempotency_key")]
+		public string IdempotencyKey { get; set; }
+	}
+}

--- a/src/Stripe.net/Entities/StripeManagedAccountKeys.cs
+++ b/src/Stripe.net/Entities/StripeManagedAccountKeys.cs
@@ -2,7 +2,7 @@
 
 namespace Stripe
 {
-    public class StripeManagedAccountKeys : StripeEntity
+    public class StripeCustomAccountKeys : StripeEntity
     {
         [JsonProperty("secret")]
         public string Secret { get; set; }

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -7,7 +7,7 @@ namespace Stripe
 {
     public static class StripeConfiguration
     {
-        public static string StripeApiVersion = "2017-04-06";
+        public static string StripeApiVersion = "2017-05-25";
         public static string StripeNetVersion { get; }
 
         /// <summary>

--- a/src/Stripe.net/Services/Account/StripeAccountCreateOptions.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountCreateOptions.cs
@@ -7,7 +7,7 @@ namespace Stripe
         [JsonProperty("country")]
         public string Country { get; set; }
 
-        [JsonProperty("managed")]
-        public bool? Managed { get; set; }
+        [JsonProperty("type")]
+        public string Type { get; set; }
     }
 }


### PR DESCRIPTION
Stripe's latest API version, [2017-05-25](https://stripe.com/docs/upgrades#2017-05-25) introduced some breaking changes that this PR aims to support:

- [x] replace `managed` by `type` on the Account resource.
- [x] replace reference to managed accounts by Custom accounts and standalone accounts by Standard accounts.
- [x] `user_id` property on the Event object is now called `account`.
- [x] `request` property on the Event object is now a hash with `request[id]` and `request[idempotency_key]`.
- [ ] confirm that the change is for `previous_attributes` on the Event object is handled gracefully.