### PR TITLE
Migrate support to netstandard1.1

### DIFF
--- a/src/Stripe.Tests.XUnit/Stripe.Tests.XUnit.csproj
+++ b/src/Stripe.Tests.XUnit/Stripe.Tests.XUnit.csproj
@@ -6,25 +6,53 @@
     <PackageId>Stripe.Tests.XUnit</PackageId>
     <RuntimeIdentifiers>win10-x64;win81-x64;osx.10.12-x64</RuntimeIdentifiers>
     <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
+    <VersionPrefix>0.0.0</VersionPrefix>
+    
+    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <AssemblyName>Stripe.Tests.XUnit</AssemblyName>
+    <PackageId>Stripe.Tests.XUnit</PackageId>
+    <DebugType>portable</DebugType>
+    <OutputType>Library</OutputType>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
   </PropertyGroup>
 
+  <!-- Include the Stripe.net project -->
   <ItemGroup>
-    <EmbeddedResource Include="_resources\*.jpg" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
+    <ProjectReference Include="..\Stripe.net\Stripe.net.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="events\event.json" />
+  <!-- Include latest NetCore -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+    <PackageReference Include="Microsoft.NetCore.App" Version="1.*" type="platform" />
   </ItemGroup>
 
+  <!-- Configure the Test Runner -->
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
   </ItemGroup>
 
+  <!-- Include test resources -->
   <ItemGroup>
-    <ProjectReference Include="..\Stripe.net\Stripe.net.csproj" />
+    <EmbeddedResource Include="_resources\*.jpg" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
+    <EmbeddedResource Include="events\event.json" />
+  </ItemGroup>
+
+  <!-- Unknown -->
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/src/Stripe.net.Tests/Stripe.net.Tests.csproj
+++ b/src/Stripe.net.Tests/Stripe.net.Tests.csproj
@@ -2,25 +2,45 @@
 
   <PropertyGroup>
     <VersionPrefix>0.0.0</VersionPrefix>
-    <TargetFramework>net46</TargetFramework>
+
+    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Stripe.net.Tests</AssemblyName>
     <PackageId>Stripe.net.Tests</PackageId>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeIdentifiers>win</RuntimeIdentifiers>
+    <DebugType>portable</DebugType>
+    <OutputType>Library</OutputType>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    
   </PropertyGroup>
 
+  <!-- Include the Stripe.net project -->
   <ItemGroup>
     <ProjectReference Include="..\Stripe.net\Stripe.net.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Machine.Specifications" Version="0.11.0" />
-    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.2.3" />
-    <PackageReference Include="Machine.Specifications.Should" Version="0.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
+  <!-- Include latest NetCore -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+    <PackageReference Include="Microsoft.NetCore.App" Version="1.*" type="platform" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <!-- Include test dependencies -->
+  <ItemGroup>
+    <PackageReference Include="Machine.Specifications" Version="0.11.0" />
+    <PackageReference Include="Machine.Specifications.Should" Version="0.11.0" />
+    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.2.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+  </ItemGroup>
+
+  <!-- Include the test resources --> 
+  <ItemGroup>
     <EmbeddedResource Include="fileuploads\test_data\logo.png" />
     <EmbeddedResource Include="infrastructure\test_data\card.json" />
     <EmbeddedResource Include="infrastructure\test_data\charge.json" />
@@ -29,24 +49,6 @@
     <EmbeddedResource Include="infrastructure\test_data\invoice.json" />
     <EmbeddedResource Include="infrastructure\test_data\invoice_item.json" />
     <EmbeddedResource Include="infrastructure\test_data\subscription.json" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Collections" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.Remoting" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Serialization" />
-    <Reference Include="System" />
   </ItemGroup>
 
 </Project>

--- a/src/Stripe.net.Tests/infrastructure/when_building_the_client.cs
+++ b/src/Stripe.net.Tests/infrastructure/when_building_the_client.cs
@@ -34,10 +34,10 @@ namespace Stripe.Tests
             var clientData = JToken.Parse(request.Headers.GetValues("X-Stripe-Client-User-Agent").FirstOrDefault());
         };
 
-        It should_have_the_net45_for_uname = () =>
+        It should_have_the_platform_in_the_uname = () =>
         {
             var clientData = JToken.Parse(request.Headers.GetValues("X-Stripe-Client-User-Agent").FirstOrDefault());
-            clientData.SelectToken("uname").ToString().ShouldContain("net45.");
+            clientData.SelectToken("uname").ToString().ShouldContain(".platform");
         };
     }
 }

--- a/src/Stripe.net/Services/Events/StripeEventUtility.cs
+++ b/src/Stripe.net/Services/Events/StripeEventUtility.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 using Stripe.Infrastructure;
+
+using System.Security.Cryptography;
+
 
 namespace Stripe
 {
@@ -56,6 +58,7 @@ namespace Stripe
 
         private static string computeSignature(string secret, string timestamp, string payload)
         {
+
             var secretBytes = Encoding.UTF8.GetBytes(secret);
             var payloadBytes = Encoding.UTF8.GetBytes($"{timestamp}.{payload}");
 
@@ -78,5 +81,6 @@ namespace Stripe
 
             return result == 0;
         }
+
     }
 }

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -1,33 +1,47 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Stripe.net is a sync/async .NET 4.5+ client, and a portable class library for stripe.com.</Description>
+
+    <Description>Stripe.net is a sync/async .NET 4.6+ client, and a portable class library for stripe.com.</Description>
     <AssemblyTitle>Stripe.net</AssemblyTitle>
     <VersionPrefix>10.0.0</VersionPrefix>
     <Version>10.0.0</Version>
     <Authors>Jayme Davis</Authors>
     <TargetFrameworks>netstandard1.2;net45</TargetFrameworks>
+    <VersionPrefix>9.1.0</VersionPrefix>
+    <Version>9.1.0</Version>
     <AssemblyName>Stripe.net</AssemblyName>
-    <PackageId>Stripe.net</PackageId>
+    <VersionPrefix>9.0.0</VersionPrefix>
+    <Version>9.0.0</Version>
+    <Authors>Jayme Davis</Authors>
+
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net45</PackageTargetFallback>
+    <RuntimeIdentifiers>any</RuntimeIdentifiers>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+
+    <PackageId>Stripe.net</PackageId>    
     <PackageTags>stripe;payment;credit;cards;money;gateway;paypal;braintree</PackageTags>
     <PackageIconUrl>http://i.imgur.com/UuBwQ33.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/jaymedavis/stripe.net</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.github.com/jaymedavis/stripe.net/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/jaymedavis/stripe.net</RepositoryUrl>
-    <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.2' ">$(PackageTargetFallback);netcoreapp1.0</PackageTargetFallback>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.2' ">1.6.1</NetStandardImplicitPackageVersion>
     <SignAssembly>True</SignAssembly>
+
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <DefineConstants>$(DefineConstants);NET45</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <DefineConstants>$(DefineConstants);NET45</DefineConstants>
-  </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="Microsoft.CSharp" />
@@ -44,10 +58,8 @@
     <Reference Include="System" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.2'">
-    <PackageReference Include="System.Security.Cryptography.Algorithms">
-      <Version>4.3.0</Version>
-    </PackageReference>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The goal of this build is to target net45+ and netcoreapp1.*.
Unfortunately, while the project is building in netstandard1.1, I cannot
target net45 in the tests without mspec breaking.