### PR TITLE
SourceType on StripeTransferCreateOptions  

### DIFF
--- a/src/Stripe.net/Services/Transfers/StripeTransferCreateOptions.cs
+++ b/src/Stripe.net/Services/Transfers/StripeTransferCreateOptions.cs
@@ -23,5 +23,8 @@ namespace Stripe
 
         [JsonProperty("transfer_group")]
         public string TransferGroup { get; set; }
+
+        [JsonProperty("source_type")]
+        public string SourceType { get; set; }
     }
 }


### PR DESCRIPTION
This field is required so that a bank transfer can occur. Without this, the "source_type" defaults to "card", adding this allows setting the source type to "bank_account". There is no way to send bank transfers without this to my knowledge. See the Transfers API: https://stripe.com/docs/api#transfers