### PR TITLE
Adding support for the login_link resource for Express accounts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,15 @@ Updating an account has almost all the same available properties as creating an 
 
 [StripeListOptions](#stripelistoptions-paging) for paging
 
+### Creating a login link
+
+When managing Express accounts, you can allow the owner to log into their dashboard by creating a login link for them.
+
+```csharp
+	var loginLinkService = new StripeLoginLinkService();
+	StripeLoginLink loginLink = loginLinkService.Create(*accountId*);
+```
+
 Application Fees
 ----------------
 

--- a/src/Stripe.net.Tests/account/when_creating_a_login_link.cs
+++ b/src/Stripe.net.Tests/account/when_creating_a_login_link.cs
@@ -17,7 +17,9 @@ namespace Stripe.Tests
 
         Because of = () =>
         {
-            StripeLoginLink = _stripeLoginLinkService.Create("acct_1ATUvjL0EMaiKBY7");
+            // This is the id of an Express account for this library's platform.
+            // When testing locally you need to put an id valid for your platform.
+            StripeLoginLink = _stripeLoginLinkService.Create("acct_1ATVm2ETkVWzzLxp");
         };
 
         It should_have_a_url = () =>

--- a/src/Stripe.net.Tests/account/when_creating_a_login_link.cs
+++ b/src/Stripe.net.Tests/account/when_creating_a_login_link.cs
@@ -6,9 +6,8 @@ namespace Stripe.Tests
 {
     public class when_creating_a_login_link
     {
-        protected static StripeLoginLink StripeLoginLink;
-
         private static StripeLoginLinkService _stripeLoginLinkService;
+        private static StripeLoginLink _stripeLoginLink;
 
         Establish context = () =>
         {
@@ -19,10 +18,10 @@ namespace Stripe.Tests
         {
             // This is the id of an Express account for this library's platform.
             // When testing locally you need to put an id valid for your platform.
-            StripeLoginLink = _stripeLoginLinkService.Create("acct_1ATVm2ETkVWzzLxp");
+            _stripeLoginLink = _stripeLoginLinkService.Create("acct_1ATVm2ETkVWzzLxp");
         };
 
         It should_have_a_url = () =>
-            StripeLoginLink.Url.ShouldContain("http");
+            _stripeLoginLink.Url.ShouldContain("http");
     }
 }

--- a/src/Stripe.net.Tests/account/when_creating_a_login_link.cs
+++ b/src/Stripe.net.Tests/account/when_creating_a_login_link.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Linq;
+using Machine.Specifications;
+
+namespace Stripe.Tests
+{
+    public class when_creating_a_login_link
+    {
+        protected static StripeLoginLink StripeLoginLink;
+
+        private static StripeLoginLinkService _stripeLoginLinkService;
+
+        Establish context = () =>
+        {
+            _stripeLoginLinkService = new StripeLoginLinkService();
+        };
+
+        Because of = () =>
+        {
+            StripeLoginLink = _stripeLoginLinkService.Create("acct_1ATUvjL0EMaiKBY7");
+        };
+
+        It should_have_a_url = () =>
+            StripeLoginLink.Url.ShouldContain("http");
+    }
+}

--- a/src/Stripe.net/Entities/StripeLoginLink.cs
+++ b/src/Stripe.net/Entities/StripeLoginLink.cs
@@ -1,0 +1,19 @@
+using System;
+using Newtonsoft.Json;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+    public class StripeLoginLink : StripeEntity
+    {
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        [JsonProperty("created")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime Created { get; set; }
+
+        [JsonProperty("url")]
+        public string Url { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Cards/LoginLink/StripeLoginLinkService.cs
+++ b/src/Stripe.net/Services/Cards/LoginLink/StripeLoginLinkService.cs
@@ -5,17 +5,22 @@ using Stripe.Infrastructure;
 
 namespace Stripe
 {
-    public class StripeLoginLinkService : StripeService
+    public class StripeLoginLinkService : StripeBasicService<StripeLoginLink>
     {
         public StripeLoginLinkService(string apiKey = null) : base(apiKey) { }
 
         //Sync
         public virtual StripeLoginLink Create(string accountId, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeLoginLink>.MapFromJson(
-                Requestor.PostString(this.ApplyAllParameters(null, $"{Urls.BaseUrl}/accounts/{accountId}/login_links", false),
-                SetupRequestOptions(requestOptions))
-            );
+            return Post($"{Urls.BaseUrl}/accounts/{accountId}/login_links", requestOptions, null);
+        }
+
+
+
+        // Async
+        public virtual Task<StripeLoginLink> CreateAsync(string accountId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return PostAsync($"{Urls.BaseUrl}/accounts/{accountId}/login_links", requestOptions, cancellationToken, null);
         }
     }
 }

--- a/src/Stripe.net/Services/Cards/LoginLink/StripeLoginLinkService.cs
+++ b/src/Stripe.net/Services/Cards/LoginLink/StripeLoginLinkService.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+    public class StripeLoginLinkService : StripeService
+    {
+        public StripeLoginLinkService(string apiKey = null) : base(apiKey) { }
+
+        //Sync
+        public virtual StripeLoginLink Create(string accountId, StripeRequestOptions requestOptions = null)
+        {
+            return Mapper<StripeLoginLink>.MapFromJson(
+                Requestor.PostString(this.ApplyAllParameters(null, $"{Urls.BaseUrl}/accounts/{accountId}/login_links", false),
+                SetupRequestOptions(requestOptions))
+            );
+        }
+    }
+}


### PR DESCRIPTION
[Express accounts](https://stripe.com/docs/connect/express-accounts) are created via OAuth and not the API. A platform can let their user log into their dashboard by creating a login link via the [API](https://stripe.com/docs/api#create_login_link). This PR adds support for it.